### PR TITLE
Validate parameters contain schema xor content

### DIFF
--- a/src/Exception/InvalidOpenAPI.php
+++ b/src/Exception/InvalidOpenAPI.php
@@ -30,6 +30,14 @@ final class InvalidOpenAPI extends RuntimeException
         return new self($message, self::INVALID_OPEN_API);
     }
 
+    public static function mustHaveSchemaXorContent(string $name): self
+    {
+        return new self(
+            sprintf('Parameter "%s" MUST have either a Schema or Content, but not both.', $name),
+            self::INVALID_OPEN_API
+        );
+    }
+
     public static function failedCebeValidation(string ...$errors): self
     {
         $message = sprintf("OpenAPI is invalid for the following reasons:\n\t- %s", implode("\n\t- ", $errors));

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -206,6 +206,62 @@ class ReaderTest extends TestCase
             })(),
             InvalidOpenAPI::duplicateOperationIds('duplicate-id', '/firstpath', 'get', '/secondpath', 'get'),
         ];
+
+        yield 'path with parameter missing both schema and content' => [
+            (function () use ($openAPI, $openAPIPath) {
+                $openAPIArray = $openAPI;
+                $path = $openAPIPath('get-first-path');
+                $path['parameters'] = [['name' => 'param', 'in' => 'query']];
+                $openAPIArray['paths'] = ['/firstpath' => ['get' => $path]];
+                return json_encode($openAPIArray);
+            })(),
+            InvalidOpenAPI::mustHaveSchemaXorContent('param'),
+        ];
+
+        yield 'path with parameter both schema and content' => [
+            (function () use ($openAPI, $openAPIPath) {
+                $openAPIArray = $openAPI;
+                $openAPIArray['paths'] = ['/firstpath' => [
+                    'parameters' => [[
+                        'name' => 'param',
+                        'in' => 'query',
+                        'schema' => ['type' => 'string'],
+                        'content' => ['application/json' => ['type' => 'string']]
+                    ]],
+                    'get' => $openAPIPath('get-first-path')
+                ],];
+                return json_encode($openAPIArray);
+            })(),
+            InvalidOpenAPI::mustHaveSchemaXorContent('param'),
+        ];
+
+        yield 'path with operation missing both schema and content' => [
+            (function () use ($openAPI, $openAPIPath) {
+                $openAPIArray = $openAPI;
+                $openAPIArray['paths'] = ['/firstpath' => [
+                    'parameters' => [['name' => 'param', 'in' => 'query']],
+                    'get' => $openAPIPath('get-first-path')
+                ]];
+                return json_encode($openAPIArray);
+            })(),
+            InvalidOpenAPI::mustHaveSchemaXorContent('param'),
+        ];
+
+        yield 'path with operation both schema and content' => [
+            (function () use ($openAPI, $openAPIPath) {
+                $openAPIArray = $openAPI;
+                $path = $openAPIPath('get-first-path');
+                $path['parameters'] = [[
+                    'name' => 'param',
+                    'in' => 'query',
+                    'schema' => ['type' => 'string'],
+                    'content' => ['application/json' => ['type' => 'string']]
+                ]];
+                $openAPIArray['paths'] = ['/firstpath' => ['get' => $path],];
+                return json_encode($openAPIArray);
+            })(),
+            InvalidOpenAPI::mustHaveSchemaXorContent('param'),
+        ];
     }
 
     #[Test]


### PR DESCRIPTION
_A parameter MUST contain either a schema property, or a content property, but not both._ (OpenAPI Specification 3.0.3)

The Cebe library currently only invalidates parameters that contain both. It considers a parameter without either to be valid.

This PR throws a Membrane InvalidOpenAPI exception for both invalid cases.