### PR TITLE
Adjust Parameter conflict criteria

### DIFF
--- a/src/Exception/InvalidOpenAPI.php
+++ b/src/Exception/InvalidOpenAPI.php
@@ -280,6 +280,16 @@ final class InvalidOpenAPI extends RuntimeException
         return new self($message);
     }
 
+    public static function deepObjectMustBeObject(Identifier $identifier): self
+    {
+        $message = <<<TEXT
+            $identifier
+            style:deepObject is only applicable to schemas of type:object
+            Therefore, your schema MUST be valid ONLY as type:object
+            TEXT;
+
+        return new self($message);
+    }
     public static function invalidType(Identifier $identifier, string $type): self
     {
         $message = <<<TEXT

--- a/src/ValueObject/Valid/V30/Operation.php
+++ b/src/ValueObject/Valid/V30/Operation.php
@@ -127,7 +127,7 @@ final class Operation extends Validated
                     );
                 }
 
-                if ($parameter->canConflict($otherParameter)) {
+                if ($parameter->canConflictWith($otherParameter)) {
                     throw CannotSupport::conflictingParameterStyles(
                         (string) $parameter->getIdentifier(),
                         (string) $otherParameter->getIdentifier(),

--- a/src/ValueObject/Valid/V30/Schema.php
+++ b/src/ValueObject/Valid/V30/Schema.php
@@ -129,9 +129,15 @@ final class Schema extends Validated
         return [$type] === $this->typesItCanBe;
     }
 
-    public function canOnlyBePrimitive(): bool
+    public function canBePrimitive(): bool
     {
-        return !$this->canBe(Type::Array) && !$this->canBe(Type::Object);
+        foreach ($this->typesItCanBe as $typeItCanBe) {
+            if ($typeItCanBe->isPrimitive()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /** @return string[] */

--- a/tests/MembraneReaderTest.php
+++ b/tests/MembraneReaderTest.php
@@ -602,77 +602,7 @@ class MembraneReaderTest extends TestCase
             'responses' => [200 => ['description' => ' Successful Response']]
         ];
 
-        yield 'operation with two spaceDelimited exploding arrays' => [
-            json_encode(
-                $openAPI($path(
-                    [],
-                    $operation([
-                        'operationId' => 'test-op',
-                        'parameters' => [
-                            [
-                                'name' => 'param1',
-                                'in' => 'query',
-                                'explode' => true,
-                                'style' => 'spaceDelimited',
-                                'schema' => ['type' => 'array'],
-                            ],
-                            [
-                                'name' => 'param2',
-                                'in' => 'query',
-                                'explode' => true,
-                                'style' => 'spaceDelimited',
-                                'schema' => ['type' => 'array'],
-                            ]
-                        ],
-                    ])
-                ))
-            ),
-            CannotSupport::conflictingParameterStyles(
-                '["test-api(1.0.0)"]["/path"]["test-op(get)"]["param1(query)"]',
-                '["test-api(1.0.0)"]["/path"]["test-op(get)"]["param2(query)"]',
-            )
-        ];
-
-        yield 'spaceDelimited exploding in path, pipeDelimited exploding in query and spaceDelimited exploding in query' => [
-            json_encode(
-                $openAPI($path(
-                    [
-                        [
-                            'name' => 'param1',
-                            'in' => 'query',
-                            'explode' => true,
-                            'style' => 'spaceDelimited',
-                            'schema' => ['type' => 'array'],
-                        ],
-                    ],
-                    $operation([
-                        'operationId' => 'test-op',
-                        'parameters' => [
-                            [
-                                'name' => 'param2',
-                                'in' => 'query',
-                                'explode' => true,
-                                'style' => 'pipeDelimited',
-                                'schema' => ['type' => 'array'],
-                            ],
-                            [
-                                'name' => 'param3',
-                                'in' => 'query',
-                                'explode' => true,
-                                'style' => 'spaceDelimited',
-                                'schema' => ['type' => 'array'],
-                            ]
-                        ],
-                    ])
-                ))
-            ),
-            CannotSupport::conflictingParameterStyles(
-                '["test-api(1.0.0)"]["/path"]["test-op(get)"]["param3(query)"]',
-                '["test-api(1.0.0)"]["/path"]["param1(query)"]',
-            )
-        ];
-
-        yield 'form exploding object in path, pipeDelimited object in path, pipeDelimited exploding in query' => [
+        yield 'form exploding object in path, pipeDelimited object in path, form exploding in operation' => [
             json_encode(
                 $openAPI($path(
                     [
@@ -698,7 +628,7 @@ class MembraneReaderTest extends TestCase
                                 'name' => 'param3',
                                 'in' => 'query',
                                 'explode' => true,
-                                'style' => 'pipeDelimited',
+                                'style' => 'form',
                                 'schema' => ['type' => 'array'],
                             ]
                         ],
@@ -707,6 +637,34 @@ class MembraneReaderTest extends TestCase
             ),
             CannotSupport::conflictingParameterStyles(
                 '["test-api(1.0.0)"]["/path"]["test-op(get)"]["param3(query)"]',
+                '["test-api(1.0.0)"]["/path"]["param1(query)"]',
+            )
+        ];
+
+        yield 'form exploding object in path, pipeDelimited primitive in path, form exploding in operation' => [
+            json_encode(
+                $openAPI($path(
+                    [
+                        [
+                            'name' => 'param1',
+                            'in' => 'query',
+                            'explode' => true,
+                            'style' => 'form',
+                            'schema' => ['type' => 'object'],
+                        ],
+                        [
+                            'name' => 'param2',
+                            'in' => 'query',
+                            'explode' => true,
+                            'style' => 'pipeDelimited',
+                            'schema' => ['type' => 'string'],
+                        ],
+                    ],
+                    $operation(['operationId' => 'test-op'])
+                ))
+            ),
+            CannotSupport::conflictingParameterStyles(
+                '["test-api(1.0.0)"]["/path"]["param1(query)"]',
                 '["test-api(1.0.0)"]["/path"]["param2(query)"]',
             )
         ];

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -524,77 +524,7 @@ class ReaderTest extends TestCase
             'responses' => [200 => ['description' => ' Successful Response']]
         ];
 
-        yield 'operation with two spaceDelimited exploding arrays' => [
-            json_encode(
-                $openAPI($path(
-                    [],
-                    $operation([
-                        'operationId' => 'test-op',
-                        'parameters' => [
-                            [
-                                'name' => 'param1',
-                                'in' => 'query',
-                                'explode' => true,
-                                'style' => 'spaceDelimited',
-                                'schema' => ['type' => 'array'],
-                            ],
-                            [
-                                'name' => 'param2',
-                                'in' => 'query',
-                                'explode' => true,
-                                'style' => 'spaceDelimited',
-                                'schema' => ['type' => 'array'],
-                            ]
-                        ],
-                    ])
-                ))
-            ),
-            CannotSupport::conflictingParameterStyles(
-                '["test-api(1.0.0)"]["/path"]["test-op(get)"]["param1(query)"]',
-                '["test-api(1.0.0)"]["/path"]["test-op(get)"]["param2(query)"]',
-            )
-        ];
-
-        yield 'spaceDelimited exploding in path, pipeDelimited exploding in query and spaceDelimited exploding in query' => [
-            json_encode(
-                $openAPI($path(
-                    [
-                        [
-                            'name' => 'param1',
-                            'in' => 'query',
-                            'explode' => true,
-                            'style' => 'spaceDelimited',
-                            'schema' => ['type' => 'array'],
-                        ],
-                    ],
-                    $operation([
-                        'operationId' => 'test-op',
-                        'parameters' => [
-                            [
-                                'name' => 'param2',
-                                'in' => 'query',
-                                'explode' => true,
-                                'style' => 'pipeDelimited',
-                                'schema' => ['type' => 'array'],
-                            ],
-                            [
-                                'name' => 'param3',
-                                'in' => 'query',
-                                'explode' => true,
-                                'style' => 'spaceDelimited',
-                                'schema' => ['type' => 'array'],
-                            ]
-                        ],
-                    ])
-                ))
-            ),
-            CannotSupport::conflictingParameterStyles(
-                '["test-api(1.0.0)"]["/path"]["test-op(get)"]["param3(query)"]',
-                '["test-api(1.0.0)"]["/path"]["param1(query)"]',
-            )
-        ];
-
-        yield 'form exploding object in path, pipeDelimited object in path, pipeDelimited exploding in query' => [
+        yield 'form exploding object in path, pipeDelimited object in path, form exploding in operation' => [
             json_encode(
                 $openAPI($path(
                     [
@@ -620,7 +550,7 @@ class ReaderTest extends TestCase
                                 'name' => 'param3',
                                 'in' => 'query',
                                 'explode' => true,
-                                'style' => 'pipeDelimited',
+                                'style' => 'form',
                                 'schema' => ['type' => 'array'],
                             ]
                         ],
@@ -629,6 +559,34 @@ class ReaderTest extends TestCase
             ),
             CannotSupport::conflictingParameterStyles(
                 '["test-api(1.0.0)"]["/path"]["test-op(get)"]["param3(query)"]',
+                '["test-api(1.0.0)"]["/path"]["param1(query)"]',
+            )
+        ];
+
+        yield 'form exploding object in path, pipeDelimited primitive in path, form exploding in operation' => [
+            json_encode(
+                $openAPI($path(
+                    [
+                        [
+                            'name' => 'param1',
+                            'in' => 'query',
+                            'explode' => true,
+                            'style' => 'form',
+                            'schema' => ['type' => 'object'],
+                        ],
+                        [
+                            'name' => 'param2',
+                            'in' => 'query',
+                            'explode' => true,
+                            'style' => 'pipeDelimited',
+                            'schema' => ['type' => 'string'],
+                        ],
+                    ],
+                    $operation(['operationId' => 'test-op'])
+                ))
+            ),
+            CannotSupport::conflictingParameterStyles(
+                '["test-api(1.0.0)"]["/path"]["param1(query)"]',
                 '["test-api(1.0.0)"]["/path"]["param2(query)"]',
             )
         ];

--- a/tests/ValueObject/Valid/V30/MediaTypeTest.php
+++ b/tests/ValueObject/Valid/V30/MediaTypeTest.php
@@ -12,6 +12,7 @@ use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
 use Membrane\OpenAPIReader\ValueObject\Valid\V30\MediaType;
 use Membrane\OpenAPIReader\ValueObject\Valid\V30\Schema;
 use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
+use Membrane\OpenAPIReader\ValueObject\Valid\Warnings;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -25,6 +26,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(Partial\Schema::class)]
 #[UsesClass(Schema::class)]
 #[UsesClass(Type::class)]
+#[UsesClass(Warnings::class)]
 class MediaTypeTest extends TestCase
 {
     #[Test]

--- a/tests/ValueObject/Valid/V30/SchemaTest.php
+++ b/tests/ValueObject/Valid/V30/SchemaTest.php
@@ -95,9 +95,11 @@ class SchemaTest extends TestCase
         $sut = new Schema(new Identifier(''), $partialSchema);
 
         self::assertSame(
-            !in_array(Type::Object, $typesItCanBe) &&
-            !in_array(Type::Array, $typesItCanBe),
-            $sut->canOnlyBePrimitive()
+            !empty(array_filter($typesItCanBe, fn($t) => !in_array(
+                $t,
+                [Type::Array, Type::Object]
+            ))),
+            $sut->canBePrimitive()
         );
     }
 


### PR DESCRIPTION
This PR is the result of [OpenAPI-Specification #3737](https://github.com/OAI/OpenAPI-Specification/issues/3737)

`spaceDelimited` and `pipeDelimited` should not conflict _in most cases_ as they will have their parameter names stated first, i.e.
`tags=cat%20shorthair%20calico`
`tags=cat|shorthair|calico`

I also added a stricter requirement on `deepObject` to **invalidate an api** for allowing it to be anything other than `object`. This is because it does not make sense to use it for anything else and you cannot pick a "backup style" so how would we resolve it?

I've left `spaceDelimited` and `pipeDelimited` primitives as "acceptable" since, though not technically valid, it would look identical to `type:array` with one item in it.