### PR TITLE
Add withoutServer method to OpenAPI object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     "cebe/php-openapi": "^1.7"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.1",
-    "phpstan/phpstan": "^1.10.56",
-    "squizlabs/php_codesniffer": "^3.7",
+    "phpunit/phpunit": "^10.5.36",
+    "phpstan/phpstan": "^1.12.6",
+    "squizlabs/php_codesniffer": "^3.5.4",
     "mikey179/vfsstream": "^1.6.7",
-    "infection/infection": "^0.27.0"
+    "infection/infection": "^0.29.7"
   },
   "config": {
     "allow-plugins": {

--- a/src/Factory/V30/FromCebe.php
+++ b/src/Factory/V30/FromCebe.php
@@ -26,11 +26,11 @@ final class FromCebe
 
         /**
          * todo when phpstan 1.11 stable is released
-         * replace the below lines with @phpstan-ignore nullsafe.neverNull
+         * replace the below lines with phpstan-ignore nullsafe.neverNull
          * The reason for this is the cebe library does not specify that info is nullable
          * However it is not always set, so it can be null
          */
-        return new Valid\V30\OpenAPI(new OpenAPI(
+        return Valid\V30\OpenAPI::fromPartial(new OpenAPI(
             $openApi->openapi,
             $openApi->info?->title, // @phpstan-ignore-line
             $openApi->info?->version, // @phpstan-ignore-line

--- a/src/ValueObject/Valid/Identifier.php
+++ b/src/ValueObject/Valid/Identifier.php
@@ -16,7 +16,7 @@ final class Identifier implements Stringable
         $this->chain = [$field, ...$fields];
     }
 
-    public function append(string $primaryId, string $secondaryId = ''): self
+    public function append(string $primaryId, string $secondaryId = ''): Identifier
     {
         $field = sprintf(
             '%s%s',
@@ -24,10 +24,15 @@ final class Identifier implements Stringable
             $secondaryId === '' ? '' : "($secondaryId)"
         );
 
-        return new self(...[...$this->chain, $field]);
+        return new Identifier(...[...$this->chain, $field]);
     }
 
-    public function fromEnd(int $level): ?string
+    public function fromStart(int $level = 0): ?string
+    {
+        return $this->chain[$level] ?? null;
+    }
+
+    public function fromEnd(int $level = 0): ?string
     {
         return array_reverse($this->chain)[$level] ?? null;
     }

--- a/tests/ValueObject/Valid/IdentifierTest.php
+++ b/tests/ValueObject/Valid/IdentifierTest.php
@@ -60,7 +60,65 @@ class IdentifierTest extends TestCase
         self::assertSame($expected, (string)$sut);
     }
 
-    public static function provideChainsToSearchThrough(): Generator
+    /** @param string[] $chain */
+    #[Test, DataProvider('provideChainsToSearchThroughForwards')]
+    public function itGetsStringsFromStartOfChain(
+        ?string $expected,
+        int $index,
+        array $chain,
+    ): void {
+        $sut = new Identifier(...$chain);
+
+        self::assertSame($expected, $sut->fromStart($index));
+    }
+
+    /** @param string[] $chain */
+    #[Test, DataProvider('provideChainsToSearchThroughBackwards')]
+    public function itGetsStringsFromEndOfChain(
+        ?string $expected,
+        int $index,
+        array $chain,
+    ): void {
+        $sut = new Identifier(...$chain);
+
+        self::assertSame($expected, $sut->fromEnd($index));
+    }
+
+    public static function provideChainsToSearchThroughForwards(): Generator
+    {
+        yield 'single field, first field from start' => [
+            'field1',
+            0,
+            ['field1']
+        ];
+
+        yield 'single field, second field from start which should be null' => [
+            null,
+            1,
+            ['field1']
+        ];
+
+        yield 'three fields, pick the first from start' => [
+            'field1',
+            0,
+            ['field1', 'field2', 'field3']
+        ];
+
+        yield 'three fields, pick the second from start' => [
+            'field2',
+            1,
+            ['field1', 'field2', 'field3']
+        ];
+
+        yield 'three fields, pick the third from start' => [
+            'field3',
+            2,
+            ['field1', 'field2', 'field3']
+        ];
+    }
+
+
+    public static function provideChainsToSearchThroughBackwards(): Generator
     {
         yield 'single field, first field from end' => [
             'field1',
@@ -91,17 +149,5 @@ class IdentifierTest extends TestCase
             2,
             ['field1', 'field2', 'field3']
         ];
-    }
-
-    /** @param string[] $chain */
-    #[Test, DataProvider('provideChainsToSearchThrough')]
-    public function itGetsStringsFromEndOfChain(
-        ?string $expected,
-        int $index,
-        array $chain,
-    ): void {
-        $sut = new Identifier(...$chain);
-
-        self::assertSame($expected, $sut->fromEnd($index));
     }
 }

--- a/tests/fixtures/Helper/OpenAPIProvider.php
+++ b/tests/fixtures/Helper/OpenAPIProvider.php
@@ -45,7 +45,7 @@ final class OpenAPIProvider
      */
     public static function minimalV30MembraneObject(): OpenAPI
     {
-        return new OpenAPI(PartialHelper::createOpenAPI(
+        return OpenAPI::fromPartial(PartialHelper::createOpenAPI(
             openapi: '3.0.0',
             title: 'My Minimal OpenAPI',
             version: '1.0.0',
@@ -186,7 +186,7 @@ final class OpenAPIProvider
      */
     public static function detailedV30MembraneObject(): OpenAPI
     {
-        return new OpenAPI(PartialHelper::createOpenAPI(
+        return OpenAPI::fromPartial(PartialHelper::createOpenAPI(
             openapi: '3.0.0',
             title: 'My Detailed OpenAPI',
             version: '1.0.1',


### PR DESCRIPTION
Alternative is to hold onto the Partial object as a property. Then we can make edits to it and reuse existing logic.

This alternative would probably make any future "edit" functions a lot simpler.