### PR TITLE
Router mvp 3.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require": {
     "php": "^8.1.0",
-    "cebe/php-openapi": "dev-fix-3.1@dev"
+    "cebe/php-openapi": "dev-all-membrane-3.1-fixes@dev"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5.36",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require": {
     "php": "^8.1.0",
-    "devizzent/cebe-php-openapi": "^1.1.0"
+    "cebe/php-openapi": "dev-fix-3.1@dev"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5.36",
@@ -29,5 +29,11 @@
     "allow-plugins": {
       "infection/extension-installer": true
     }
-  }
+  },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/charjr/php-openapi"
+    }
+  ]
 }

--- a/src/Exception/InvalidOpenAPI.php
+++ b/src/Exception/InvalidOpenAPI.php
@@ -409,4 +409,16 @@ final class InvalidOpenAPI extends RuntimeException
 
         return new self($message);
     }
+
+    public static function mustHaveStringKeys(
+        Identifier $identifier,
+        string $keyword,
+    ): self {
+        $message = <<<TEXT
+            $identifier
+            $keyword MUST be specified an array with string keys
+            TEXT;
+
+        return new self($message);
+    }
 }

--- a/src/Factory/V30/FromCebe.php
+++ b/src/Factory/V30/FromCebe.php
@@ -44,7 +44,7 @@ final class FromCebe
      * @param Cebe\Server[] $servers
      * @return Server[]
      */
-    private static function createServers(array $servers): array
+    public static function createServers(array $servers): array
     {
         $result = [];
 
@@ -62,7 +62,7 @@ final class FromCebe
      * @param Cebe\ServerVariable[] $serverVariables
      * @return ServerVariable[]
      */
-    private static function createServerVariables(array $serverVariables): array
+    public static function createServerVariables(array $serverVariables): array
     {
         $result = [];
 
@@ -81,7 +81,7 @@ final class FromCebe
      * @param null|Cebe\Paths<string,Cebe\PathItem> $paths
      * @return PathItem[]
      */
-    private static function createPaths(?Cebe\Paths $paths): array
+    public static function createPaths(?Cebe\Paths $paths): array
     {
         $result = [];
 
@@ -108,7 +108,7 @@ final class FromCebe
      * @param Cebe\Parameter[]|Cebe\Reference[] $parameters
      * @return Parameter[]
      */
-    private static function createParameters(array $parameters): array
+    public static function createParameters(array $parameters): array
     {
         $result = [];
 
@@ -129,7 +129,7 @@ final class FromCebe
         return $result;
     }
 
-    private static function createSchema(
+    public static function createSchema(
         Cebe\Reference|Cebe\Schema|null $schema
     ): ?Schema {
         assert(!$schema instanceof Cebe\Reference);
@@ -184,7 +184,7 @@ final class FromCebe
      * @param Cebe\MediaType[] $mediaTypes
      * @return MediaType[]
      */
-    private static function createContent(array $mediaTypes): array
+    public static function createContent(array $mediaTypes): array
     {
         $result = [];
 
@@ -202,7 +202,7 @@ final class FromCebe
         return $result;
     }
 
-    private static function createOperation(
+    public static function createOperation(
         ?Cebe\Operation $operation
     ): ?Operation {
         if (is_null($operation)) {

--- a/src/Factory/V30/FromCebe.php
+++ b/src/Factory/V30/FromCebe.php
@@ -175,6 +175,8 @@ final class FromCebe
                 self::createSchema($schema->additionalProperties) ?? true) :
                 true,
             format: $schema->format ?? null,
+            title: $schema->title ?? null,
+            description: $schema->description ?? null,
         );
     }
 

--- a/src/Factory/V31/FromCebe.php
+++ b/src/Factory/V31/FromCebe.php
@@ -188,6 +188,7 @@ final class FromCebe
             additionalProperties: is_bool($schema->additionalProperties) ?
                 $schema->additionalProperties :
                 self::createSchema($schema->additionalProperties) ?? true,
+            format: $schema->format ?? null,
         );
     }
 

--- a/src/Factory/V31/FromCebe.php
+++ b/src/Factory/V31/FromCebe.php
@@ -188,6 +188,8 @@ final class FromCebe
                 $schema->additionalProperties :
                 self::createSchema($schema->additionalProperties) ?? true,
             format: $schema->format ?? null,
+            title: $schema->title ?? null,
+            description: $schema->description ?? null,
         );
     }
 

--- a/src/Factory/V31/FromCebe.php
+++ b/src/Factory/V31/FromCebe.php
@@ -180,11 +180,8 @@ final class FromCebe
             dependentSchemas: isset($schema->dependentSchemas) ?
                 $createSchemas($schema->dependentSchemas) :
                 null,
-            items: isset($schema->items) ? (is_array($schema->items) ?
-                $createSchemas($schema->items) :
-                self::createSchema($schema->items)) :
-                null,
-            properties: isset($schema->properties) ? $createSchemas($schema->properties) : null,
+            items: isset($schema->items) ? self::createSchema($schema->items) : null,
+            properties: isset($schema->properties) ? $createSchemas($schema->properties) : [],
             additionalProperties: is_bool($schema->additionalProperties) ?
                 $schema->additionalProperties :
                 self::createSchema($schema->additionalProperties) ?? true,

--- a/src/Factory/V31/FromCebe.php
+++ b/src/Factory/V31/FromCebe.php
@@ -145,8 +145,10 @@ final class FromCebe
 
         return new Schema(
             type: $schema->type,
-            enum: $schema->enum ?? null,
-            const: $schema->const ?? null,
+            enum: isset($schema->enum) ?
+                array_map(fn($e) => new Value($e), $schema->enum) :
+                null,
+            const: isset($schema->const) ? new Value($schema->const) : null,
             default: isset($schema->default) ? new Value($schema->default) : null,
             nullable: $schema->nullable ?? false,
             multipleOf: $schema->multipleOf ?? null,

--- a/src/Factory/V31/FromCebe.php
+++ b/src/Factory/V31/FromCebe.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\Factory\V31;
+
+use cebe\openapi\spec as Cebe;
+use Membrane\OpenAPIReader\ValueObject\Partial\MediaType;
+use Membrane\OpenAPIReader\ValueObject\Partial\OpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Partial\Operation;
+use Membrane\OpenAPIReader\ValueObject\Partial\Parameter;
+use Membrane\OpenAPIReader\ValueObject\Partial\PathItem;
+use Membrane\OpenAPIReader\ValueObject\Partial\Schema;
+use Membrane\OpenAPIReader\ValueObject\Partial\Server;
+use Membrane\OpenAPIReader\ValueObject\Partial\ServerVariable;
+use Membrane\OpenAPIReader\ValueObject\Valid\V31;
+use Membrane\OpenAPIReader\ValueObject\Value;
+
+final class FromCebe
+{
+    public static function createOpenAPI(
+        Cebe\OpenApi $openApi
+    ): V31\OpenAPI {
+        $servers = count($openApi->servers) === 1 && $openApi->servers[0]->url === '/' ?
+            [] :
+            $openApi->servers;
+
+        /**
+         * todo when phpstan 1.11 stable is released
+         * replace the below lines with phpstan-ignore nullsafe.neverNull
+         * The reason for this is the cebe library does not specify that info is nullable
+         * However it is not always set, so it can be null
+         */
+        return V31\OpenAPI::fromPartial(new OpenAPI(
+            $openApi->openapi,
+            $openApi->info?->title, // @phpstan-ignore-line
+            $openApi->info?->version, // @phpstan-ignore-line
+            self::createServers($servers),
+            self::createPaths($openApi->paths)
+        ));
+    }
+
+    /**
+     * @param Cebe\Server[] $servers
+     * @return Server[]
+     */
+    private static function createServers(array $servers): array
+    {
+        $result = [];
+
+        foreach ($servers as $server) {
+            $result[] = new Server(
+                $server->url,
+                self::createServerVariables($server->variables)
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param Cebe\ServerVariable[] $serverVariables
+     * @return ServerVariable[]
+     */
+    private static function createServerVariables(array $serverVariables): array
+    {
+        $result = [];
+
+        foreach ($serverVariables as $name => $serverVariable) {
+            $result[] = new ServerVariable(
+                $name,
+                $serverVariable->default,
+                $serverVariable->enum,
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param null|Cebe\Paths<string,Cebe\PathItem> $paths
+     * @return PathItem[]
+     */
+    private static function createPaths(?Cebe\Paths $paths): array
+    {
+        $result = [];
+
+        foreach ($paths ?? [] as $path => $pathItem) {
+            $result[] = new PathItem(
+                path: $path,
+                servers: self::createServers($pathItem->servers),
+                parameters: self::createParameters($pathItem->parameters),
+                get: self::createOperation($pathItem->get),
+                put: self::createOperation($pathItem->put),
+                post: self::createOperation($pathItem->post),
+                delete: self::createOperation($pathItem->delete),
+                options: self::createOperation($pathItem->options),
+                head: self::createOperation($pathItem->head),
+                patch: self::createOperation($pathItem->patch),
+                trace: self::createOperation($pathItem->trace),
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param Cebe\Parameter[]|Cebe\Reference[] $parameters
+     * @return Parameter[]
+     */
+    private static function createParameters(array $parameters): array
+    {
+        $result = [];
+
+        foreach ($parameters as $parameter) {
+            assert(!$parameter instanceof Cebe\Reference);
+
+            $result[] = new Parameter(
+                $parameter->name,
+                $parameter->in,
+                $parameter->required,
+                $parameter->style,
+                $parameter->explode,
+                self::createSchema($parameter->schema),
+                self::createContent($parameter->content),
+            );
+        }
+
+        return $result;
+    }
+
+    private static function createSchema(
+        Cebe\Reference|Cebe\Schema|null $schema
+    ): ?Schema {
+        assert(!$schema instanceof Cebe\Reference);
+
+        if ($schema === null) {
+            return null;
+        }
+
+        $createSchemas = fn($schemas) => array_filter(
+            array_map(fn($s) => self::createSchema($s), $schemas),
+            fn($s) => $s !== null,
+        );
+
+        return new Schema(
+            type: $schema->type,
+            enum: $schema->enum ?? null,
+            const: $schema->const ?? null,
+            default: isset($schema->default) ? new Value($schema->default) : null,
+            nullable: $schema->nullable ?? false,
+            multipleOf: $schema->multipleOf ?? null,
+            exclusiveMaximum: $schema->exclusiveMaximum !== false ?
+                $schema->exclusiveMaximum :
+                null,
+            exclusiveMinimum: $schema->exclusiveMinimum !== false ?
+                $schema->exclusiveMinimum :
+                null,
+            maximum: $schema->maximum ?? null,
+            minimum: $schema->minimum ?? null,
+            maxLength: $schema->maxLength ?? null,
+            minLength: $schema->minLength ?? 0,
+            pattern: $schema->pattern ?? null,
+            maxItems: $schema->maxItems ?? null,
+            minItems: $schema->minItems ?? 0,
+            uniqueItems: $schema->uniqueItems ?? false,
+            maxContains: $schema->maxContains ?? null,
+            minContains: $schema->minContains ?? null,
+            maxProperties: $schema->maxProperties ?? null,
+            minProperties: $schema->minProperties ?? 0,
+            required: $schema->required ?? null,
+            dependentRequired: $schema->dependentRequired ?? null,
+            allOf: isset($schema->allOf) ? $createSchemas($schema->allOf) : null,
+            anyOf: isset($schema->anyOf) ? $createSchemas($schema->anyOf) : null,
+            oneOf: isset($schema->oneOf) ? $createSchemas($schema->oneOf) : null,
+            not: isset($schema->not) ? self::createSchema($schema->not) : null,
+            if: isset($schema->if) ? self::createSchema($schema->if) : null,
+            then: isset($schema->then) ? self::createSchema($schema->then) : null,
+            else: isset($schema->else) ? self::createSchema($schema->else) : null,
+            dependentSchemas: isset($schema->dependentSchemas) ?
+                $createSchemas($schema->dependentSchemas) :
+                null,
+            items: isset($schema->items) ? (is_array($schema->items) ?
+                $createSchemas($schema->items) :
+                self::createSchema($schema->items)) :
+                null,
+            properties: isset($schema->properties) ? $createSchemas($schema->properties) : null,
+            additionalProperties: is_bool($schema->additionalProperties) ?
+                $schema->additionalProperties :
+                self::createSchema($schema->additionalProperties) ?? true,
+        );
+    }
+
+    /**
+     * @param Cebe\MediaType[] $mediaTypes
+     * @return MediaType[]
+     */
+    private static function createContent(array $mediaTypes): array
+    {
+        $result = [];
+
+        foreach ($mediaTypes as $mediaType => $mediaTypeObject) {
+            assert(!$mediaTypeObject->schema instanceof Cebe\Reference);
+
+            $result[] = new MediaType(
+                is_string($mediaType) ? $mediaType : null,
+                !is_null($mediaTypeObject->schema) ?
+                    self::createSchema($mediaTypeObject->schema) :
+                    null
+            );
+        }
+
+        return $result;
+    }
+
+    private static function createOperation(
+        ?Cebe\Operation $operation
+    ): ?Operation {
+        if (is_null($operation)) {
+            return null;
+        }
+
+        return new Operation(
+            operationId: $operation->operationId,
+            servers: self::createServers($operation->servers),
+            parameters: self::createParameters($operation->parameters)
+        );
+    }
+}

--- a/src/Factory/V31/FromCebe.php
+++ b/src/Factory/V31/FromCebe.php
@@ -44,7 +44,7 @@ final class FromCebe
      * @param Cebe\Server[] $servers
      * @return Server[]
      */
-    private static function createServers(array $servers): array
+    public static function createServers(array $servers): array
     {
         $result = [];
 
@@ -62,7 +62,7 @@ final class FromCebe
      * @param Cebe\ServerVariable[] $serverVariables
      * @return ServerVariable[]
      */
-    private static function createServerVariables(array $serverVariables): array
+    public static function createServerVariables(array $serverVariables): array
     {
         $result = [];
 
@@ -81,7 +81,7 @@ final class FromCebe
      * @param null|Cebe\Paths<string,Cebe\PathItem> $paths
      * @return PathItem[]
      */
-    private static function createPaths(?Cebe\Paths $paths): array
+    public static function createPaths(?Cebe\Paths $paths): array
     {
         $result = [];
 
@@ -108,7 +108,7 @@ final class FromCebe
      * @param Cebe\Parameter[]|Cebe\Reference[] $parameters
      * @return Parameter[]
      */
-    private static function createParameters(array $parameters): array
+    public static function createParameters(array $parameters): array
     {
         $result = [];
 
@@ -129,7 +129,7 @@ final class FromCebe
         return $result;
     }
 
-    private static function createSchema(
+    public static function createSchema(
         Cebe\Reference|Cebe\Schema|null $schema
     ): ?Schema {
         assert(!$schema instanceof Cebe\Reference);
@@ -195,7 +195,7 @@ final class FromCebe
      * @param Cebe\MediaType[] $mediaTypes
      * @return MediaType[]
      */
-    private static function createContent(array $mediaTypes): array
+    public static function createContent(array $mediaTypes): array
     {
         $result = [];
 
@@ -213,7 +213,7 @@ final class FromCebe
         return $result;
     }
 
-    private static function createOperation(
+    public static function createOperation(
         ?Cebe\Operation $operation
     ): ?Operation {
         if (is_null($operation)) {

--- a/src/MembraneReader.php
+++ b/src/MembraneReader.php
@@ -21,11 +21,6 @@ final class MembraneReader
         if (empty($this->supportedVersions)) {
             throw CannotSupport::noSupportedVersions();
         }
-
-        /** todo create 3.1 validated objects */
-        if ($this->supportedVersions !== [OpenAPIVersion::Version_3_0]) {
-            throw CannotSupport::membraneReaderOnlySupportsv30();
-        }
     }
 
     public function readFromAbsoluteFilePath(string $absoluteFilePath, ?FileFormat $fileFormat = null): OpenAPI

--- a/src/MembraneReader.php
+++ b/src/MembraneReader.php
@@ -7,8 +7,7 @@ namespace Membrane\OpenAPIReader;
 use cebe\{openapi as Cebe, openapi\exceptions as CebeException, openapi\spec as CebeSpec};
 use Closure;
 use Membrane\OpenAPIReader\Exception\{CannotRead, CannotSupport, InvalidOpenAPI};
-use Membrane\OpenAPIReader\Factory\V30\FromCebe;
-use Membrane\OpenAPIReader\ValueObject\Valid\V30\OpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Valid;
 use Symfony\Component\Yaml\Exception\ParseException;
 use TypeError;
 
@@ -23,8 +22,10 @@ final class MembraneReader
         }
     }
 
-    public function readFromAbsoluteFilePath(string $absoluteFilePath, ?FileFormat $fileFormat = null): OpenAPI
-    {
+    public function readFromAbsoluteFilePath(
+        string $absoluteFilePath,
+        ?FileFormat $fileFormat = null
+    ): Valid\V30\OpenAPI|Valid\V31\OpenAPI {
         file_exists($absoluteFilePath) ?: throw CannotRead::fileNotFound($absoluteFilePath);
 
         $fileFormat ??= FileFormat::fromFileExtension(pathinfo($absoluteFilePath, PATHINFO_EXTENSION));
@@ -42,7 +43,7 @@ final class MembraneReader
         return $this->getValidatedObject($openAPI);
     }
 
-    public function readFromString(string $openAPI, FileFormat $fileFormat): OpenAPI
+    public function readFromString(string $openAPI, FileFormat $fileFormat): Valid\V30\OpenAPI|Valid\V31\OpenAPI
     {
         if (preg_match('#\s*[\'\"]?\$ref[\'\"]?\s*:\s*[\'\"]?[^\s\'\"\#]#', $openAPI)) {
             throw CannotRead::cannotResolveExternalReferencesFromString();
@@ -72,19 +73,26 @@ final class MembraneReader
         }
     }
 
-    private function getValidatedObject(CebeSpec\OpenApi $openAPI): OpenAPI
+    private function getValidatedObject(CebeSpec\OpenApi $openAPI): Valid\V30\OpenAPI|Valid\V31\OpenAPI
     {
-        $this->isVersionSupported($openAPI->openapi) ?: throw CannotSupport::unsupportedVersion($openAPI->openapi);
+        $version = OpenAPIVersion::fromString($openAPI->openapi) ??
+            throw CannotSupport::unsupportedVersion($openAPI->openapi);
 
-        $validatedObject = FromCebe::createOpenAPI($openAPI);
+        $this->isVersionSupported($version) ?:
+            throw CannotSupport::unsupportedVersion($openAPI->openapi);
+
+        $validatedObject = match ($version) {
+            OpenAPIVersion::Version_3_0 => Factory\V30\FromCebe::createOpenAPI($openAPI),
+            OpenAPIVersion::Version_3_1 => Factory\V31\FromCebe::createOpenAPI($openAPI),
+        };
 
         $openAPI->validate() ?: throw InvalidOpenAPI::failedCebeValidation(...$openAPI->getErrors());
 
         return $validatedObject;
     }
 
-    private function isVersionSupported(string $version): bool
+    private function isVersionSupported(OpenAPIVersion $version): bool
     {
-        return in_array(OpenAPIVersion::fromString($version), $this->supportedVersions, true);
+        return in_array($version, $this->supportedVersions, true);
     }
 }

--- a/src/ValueObject/Partial/Schema.php
+++ b/src/ValueObject/Partial/Schema.php
@@ -124,6 +124,12 @@ final class Schema
          * https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-7
          */
         public string|null $format = null,
+        /**
+         * Keywords that provide additional metadata
+         * https://json-schema.org/draft/2020-12/json-schema-validation#section-9
+         */
+        public string|null $title = null,
+        public string|null $description = null,
     ) {
     }
 }

--- a/src/ValueObject/Valid/V30/Schema.php
+++ b/src/ValueObject/Valid/V30/Schema.php
@@ -296,17 +296,24 @@ final class Schema extends Validated implements Valid\Schema
     }
 
     /**
-     * @param null|array<Partial\Schema> $subSchemas
-     * @return array<Schema>
+     * @param array<string, Partial\Schema> $properties
+     * @return array<string, Schema>
      */
-    private function validateProperties(?array $subSchemas): array
+    private function validateProperties(?array $properties): array
     {
-        $subSchemas ??= [];
+        $properties ??= [];
 
         $result = [];
-        foreach ($subSchemas as $index => $subSchema) {
-            $result[] = new Schema(
-                $this->getIdentifier()->append("properties($index)"),
+        foreach ($properties as $key => $subSchema) {
+            if (!is_string($key)) {
+                throw InvalidOpenAPI::mustHaveStringKeys(
+                    $this->getIdentifier(),
+                    'properties',
+                );
+            }
+
+            $result[$key] = new Schema(
+                $this->getIdentifier()->append("properties($key)"),
                 $subSchema
             );
         }

--- a/src/ValueObject/Valid/V30/Schema.php
+++ b/src/ValueObject/Valid/V30/Schema.php
@@ -57,6 +57,9 @@ final class Schema extends Validated implements Valid\Schema
 
     public readonly string|null $format;
 
+    public readonly string|null $title;
+    public readonly string|null $description;
+
     /** @var Type[] */
     private readonly array $typesItCanBe;
 
@@ -103,6 +106,9 @@ final class Schema extends Validated implements Valid\Schema
             null;
 
         $this->format = $schema->format;
+
+        $this->title = $schema->title;
+        $this->description = $schema->description;
 
         $this->typesItCanBe = array_map(
             fn($t) => Type::from($t),

--- a/src/ValueObject/Valid/V31/MediaType.php
+++ b/src/ValueObject/Valid/V31/MediaType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\ValueObject\Valid\V31;
+
+use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
+use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
+
+final class MediaType extends Validated
+{
+    public readonly ?Schema $schema;
+
+    public function __construct(
+        Identifier $identifier,
+        Partial\MediaType $mediaType
+    ) {
+         parent::__construct($identifier);
+
+        $this->schema = isset($mediaType->schema) ?
+            new Schema($this->getIdentifier()->append('schema'), $mediaType->schema) :
+            null;
+    }
+}

--- a/src/ValueObject/Valid/V31/OpenAPI.php
+++ b/src/ValueObject/Valid/V31/OpenAPI.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\ValueObject\Valid\V31;
+
+use Membrane\OpenAPIReader\Exception\InvalidOpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
+use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
+use Membrane\OpenAPIReader\ValueObject\Valid\Warning;
+
+final class OpenAPI extends Validated
+{
+    /**
+     * @param array<int, Server> $servers
+     * Optional, may be left empty.
+     * If empty or unspecified, the array will contain the default Server.
+     * The default Server has "url" === "/" and no "variables"
+     *
+     * @param array<string,PathItem> $paths
+     * REQUIRED:
+     * It may be empty due to ACL constraints
+     * The PathItem's relative endpoint key mapped to the PathItem
+     */
+    private function __construct(
+        Identifier $identifier,
+        public readonly array $servers,
+        public readonly array $paths
+    ) {
+        parent::__construct($identifier);
+
+        $this->reviewServers($this->servers);
+        $this->reviewPaths($this->paths);
+    }
+
+    public function withoutServers(): OpenAPI
+    {
+        return new OpenAPI(
+            $this->getIdentifier(),
+            [new Server($this->getIdentifier(), new Partial\Server('/'))],
+            array_map(fn($p) => $p->withoutServers(), $this->paths),
+        );
+    }
+
+    public static function fromPartial(Partial\OpenAPI $openAPI): self
+    {
+        $identifier = new Identifier(sprintf(
+            '%s(%s)',
+            $openAPI->title ?? throw InvalidOpenAPI::missingInfo(),
+            $openAPI->version ?? throw InvalidOpenAPI::missingInfo(),
+        ));
+
+        $openAPI->openAPI ??
+            throw InvalidOpenAPI::missingOpenAPIVersion($identifier);
+
+        $servers = self::validateServers($identifier, $openAPI->servers);
+        $paths = self::validatePaths($identifier, $servers, $openAPI->paths);
+
+        return new OpenAPI($identifier, $servers, $paths);
+    }
+
+    /**
+     * @param Partial\Server[] $servers
+     * @return array<int,Server>
+     */
+    private static function validateServers(
+        Identifier $identifier,
+        array $servers
+    ): array {
+        if (empty($servers)) {
+            return [new Server($identifier, new Partial\Server('/'))];
+        }
+
+        return array_values(array_map(
+            fn($s) => new Server($identifier, $s),
+            $servers
+        ));
+    }
+
+    /**
+     * @param Server[] $servers
+     */
+    private function reviewServers(array $servers): void
+    {
+        $uniqueURLS = array_unique(array_map(fn($s) => $s->url, $servers));
+        if (count($servers) !== count($uniqueURLS)) {
+            $this->addWarning(
+                'Server URLs are not unique',
+                Warning::IDENTICAL_SERVER_URLS
+            );
+        }
+    }
+
+    /**
+     * @param Server[] $servers
+     * @param null|Partial\PathItem[] $pathItems
+     * @return array<string,PathItem>
+     */
+    private static function validatePaths(
+        Identifier $identifier,
+        array $servers,
+        ?array $pathItems
+    ): array {
+        if (is_null($pathItems)) {
+            throw InvalidOpenAPI::missingPaths($identifier);
+        }
+
+        $result = [];
+
+        foreach ($pathItems as $pathItem) {
+            if (!isset($pathItem->path)) {
+                throw InvalidOpenAPI::pathMissingEndPoint($identifier);
+            }
+
+            if (!str_starts_with($pathItem->path, '/')) {
+                throw InvalidOpenAPI::forwardSlashMustPrecedePath(
+                    $identifier,
+                    $pathItem->path
+                );
+            }
+
+            if (isset($result[$pathItem->path])) {
+                throw InvalidOpenAPI::identicalEndpoints(
+                    $result[$pathItem->path]->getIdentifier()
+                );
+            }
+
+            $result[$pathItem->path] = PathItem::fromPartial(
+                $identifier->append($pathItem->path),
+                $servers,
+                $pathItem
+            );
+        }
+
+        self::checkForEquivalentPathTemplates($result);
+        self::checkForDuplicatedOperationIds($result);
+
+        return $result;
+    }
+
+    /**
+     * @param PathItem[] $paths
+     */
+    private function reviewPaths(array $paths): void
+    {
+        if (empty($paths)) {
+            $this->addWarning('No Paths in OpenAPI', Warning::EMPTY_PATHS);
+        }
+    }
+
+    /**
+     * @param array<string,PathItem> $pathItems
+     */
+    private static function checkForEquivalentPathTemplates(array $pathItems): void
+    {
+        $regexToIdentifier = [];
+        foreach ($pathItems as $path => $pathItem) {
+            $regex = self::getPathRegex($path);
+
+            if (isset($regexToIdentifier[$regex])) {
+                throw InvalidOpenAPI::equivalentTemplates(
+                    $regexToIdentifier[$regex],
+                    $pathItem->getIdentifier()
+                );
+            }
+
+            $regexToIdentifier[$regex] = $pathItem->getIdentifier();
+        }
+    }
+
+    /**
+     * @param PathItem[] $paths
+     */
+    private static function checkForDuplicatedOperationIds(array $paths): void
+    {
+        $checked = [];
+
+        foreach ($paths as $path => $pathItem) {
+            foreach ($pathItem->getOperations() as $method => $operation) {
+                $id = $operation->operationId;
+
+                if (isset($checked[$id])) {
+                    throw InvalidOpenAPI::duplicateOperationIds(
+                        $id,
+                        $checked[$id][0],
+                        $checked[$id][1],
+                        $path,
+                        $method,
+                    );
+                }
+
+                $checked[$id] = [$path, $method];
+            }
+        }
+    }
+
+    private static function getPathRegex(string $path): string
+    {
+        $pattern = preg_replace('#{[^/]+}#', '{([^/]+)}', $path);
+
+        assert(is_string($pattern));
+
+        return $pattern;
+    }
+}

--- a/src/ValueObject/Valid/V31/Operation.php
+++ b/src/ValueObject/Valid/V31/Operation.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\ValueObject\Valid\V31;
+
+use Membrane\OpenAPIReader\Exception\CannotSupport;
+use Membrane\OpenAPIReader\Exception\InvalidOpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid\Enum\Method;
+use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
+use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
+use Membrane\OpenAPIReader\ValueObject\Valid\Warning;
+
+final class Operation extends Validated
+{
+    /**
+     * @param array<int,Server> $servers
+     * Optional, may be left empty.
+     * If empty or unspecified, the array will contain the Path level servers
+     *
+     * @param Parameter[] $parameters
+     * The list MUST NOT include duplicated parameters.
+     * A unique parameter is defined by a combination of a name and location.
+     *
+     * @param string $operationId
+     * Required by Membrane
+     * MUST be unique, value is case-sensitive.
+     */
+    private function __construct(
+        Identifier $identifier,
+        public readonly string $operationId,
+        public readonly array $servers,
+        public readonly array $parameters,
+    ) {
+        parent::__construct($identifier);
+
+        $this->reviewServers($this->servers);
+        $this->reviewParameters($this->parameters);
+    }
+
+    public function withoutServers(): Operation
+    {
+        return new Operation(
+            $this->getIdentifier(),
+            $this->operationId,
+            [new Server($this->getIdentifier(), new Partial\Server('/'))],
+            $this->parameters,
+        );
+    }
+
+    /**
+     * @param Server[] $pathServers
+     * @param Parameter[] $pathParameters
+     */
+    public static function fromPartial(
+        Identifier $parentIdentifier,
+        array $pathServers,
+        array $pathParameters,
+        Method $method,
+        Partial\Operation $operation,
+    ): Operation {
+        $operationId = $operation->operationId ??
+            throw CannotSupport::missingOperationId(
+                $parentIdentifier->fromEnd(0) ?? '',
+                $method->value,
+            );
+
+        $identifier = $parentIdentifier->append("$operationId($method->value)");
+
+        $servers = self::validateServers(
+            $identifier,
+            $pathServers,
+            $operation->servers,
+        );
+
+        $parameters = self::validateParameters(
+            $identifier,
+            $pathParameters,
+            $operation->parameters
+        );
+
+        return new Operation(
+            $identifier,
+            $operationId,
+            $servers,
+            $parameters,
+        );
+    }
+
+    /**
+     * @param array<int,Server> $pathServers
+     * @param Partial\Server[] $operationServers
+     * @return array<int,Server>>
+     */
+    private static function validateServers(
+        Identifier $identifier,
+        array $pathServers,
+        array $operationServers
+    ): array {
+        if (empty($operationServers)) {
+            return $pathServers;
+        }
+
+        $result = array_values(array_map(
+            fn($s) => new Server($identifier, $s),
+            $operationServers
+        ));
+
+        return $result;
+    }
+
+    /**
+     * @param Server[] $servers
+     */
+    private function reviewServers(array $servers): void
+    {
+        $uniqueURLS = array_unique(array_map(fn($s) => $s->url, $servers));
+        if (count($servers) !== count($uniqueURLS)) {
+            $this->addWarning(
+                'Server URLs are not unique',
+                Warning::IDENTICAL_SERVER_URLS
+            );
+        }
+    }
+
+    /**
+     * @param Parameter[] $pathParameters
+     * @param Partial\Parameter[] $operationParameters
+     * @return Parameter[]
+     */
+    private static function validateParameters(
+        Identifier $identifier,
+        array $pathParameters,
+        array $operationParameters
+    ): array {
+        $result = self::mergeParameters(
+            $identifier,
+            $operationParameters,
+            $pathParameters
+        );
+
+        foreach ($result as $index => $parameter) {
+            foreach (array_slice($result, $index + 1) as $otherParameter) {
+                if ($parameter->isIdentical($otherParameter)) {
+                    throw InvalidOpenAPI::duplicateParameters(
+                        $identifier,
+                        $parameter->getIdentifier(),
+                        $otherParameter->getIdentifier(),
+                    );
+                }
+
+                if ($parameter->canConflictWith($otherParameter)) {
+                    throw CannotSupport::conflictingParameterStyles(
+                        (string) $parameter->getIdentifier(),
+                        (string) $otherParameter->getIdentifier(),
+                    );
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /** @param array<int,Parameter> $parameters */
+    private function reviewParameters(array $parameters): void
+    {
+        foreach ($parameters as $index => $parameter) {
+            foreach (array_slice($parameters, $index + 1) as $otherParameter) {
+                if ($parameter->isSimilar($otherParameter)) {
+                    $this->addWarning(
+                        <<<TEXT
+                        'This contains confusingly similar parameter names:
+                         $parameter->name
+                         $otherParameter->name
+                        TEXT,
+                        Warning::SIMILAR_NAMES
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Partial\Parameter[] $operationParameters
+     * @param Parameter[] $pathParameters
+     * @return array<int,Parameter>
+     */
+    private static function mergeParameters(
+        Identifier $identifier,
+        array $operationParameters,
+        array $pathParameters
+    ): array {
+        $result = array_map(
+            fn($p) => new Parameter($identifier, $p),
+            $operationParameters
+        );
+
+        foreach ($pathParameters as $pathParameter) {
+            foreach ($result as $operationParameter) {
+                if ($operationParameter->isIdentical($pathParameter)) {
+                    continue 2;
+                }
+            }
+            $result[] = $pathParameter;
+        }
+
+        return array_values($result);
+    }
+}

--- a/src/ValueObject/Valid/V31/Parameter.php
+++ b/src/ValueObject/Valid/V31/Parameter.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\ValueObject\Valid\V31;
+
+use Membrane\OpenAPIReader\Exception\InvalidOpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid\Enum\In;
+use Membrane\OpenAPIReader\ValueObject\Valid\Enum\Style;
+use Membrane\OpenAPIReader\ValueObject\Valid\Enum\Type;
+use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
+use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
+use Membrane\OpenAPIReader\ValueObject\Valid\Warning;
+
+final class Parameter extends Validated
+{
+    /** REQUIRED */
+    public readonly string $name;
+
+    /** REQUIRED */
+    public readonly In $in;
+
+    /**
+     * If "in":"path"
+     * - "required" MUST be defined
+     * - "required" MUST be set to true
+     */
+    public readonly bool $required;
+
+    public readonly Style $style;
+    public readonly bool $explode;
+
+    /**
+     * A Parameter MUST define a "schema" or "content" but not both
+     */
+    public readonly ?Schema $schema;
+
+    /**
+     * A Parameter MUST have a "schema" or "content" but not both
+     * If "content" is defined:
+     * - It MUST contain only one Media Type.
+     * - That MediaType MUST define a schema.
+     * @var array<string,MediaType>
+     */
+    public readonly array $content;
+
+    public function __construct(
+        Identifier $parentIdentifier,
+        Partial\Parameter $parameter
+    ) {
+        $this->name = $parameter->name ??
+            throw InvalidOpenAPI::parameterMissingName($parentIdentifier);
+
+        $this->in = $this->validateIn(
+            $parentIdentifier,
+            $parameter->in,
+        );
+
+        $identifier = $parentIdentifier->append($this->name, $this->in->value);
+        parent::__construct($identifier);
+
+        $this->required = $this->validateRequired(
+            $identifier,
+            $this->in,
+            $parameter->required
+        );
+
+        isset($parameter->schema) === empty($parameter->content) ?:
+            throw InvalidOpenAPI::mustHaveSchemaXorContent($parameter->name);
+
+        if (isset($parameter->schema)) {
+            $this->content = [];
+            $this->schema = new Schema(
+                $this->appendedIdentifier('schema'),
+                $parameter->schema
+            );
+        } else {
+            $this->schema = null;
+
+            $this->content = $this->validateContent(
+                $this->getIdentifier(),
+                $parameter->name,
+                $parameter->content
+            );
+        }
+
+        $this->style = $this->validateStyle(
+            $identifier,
+            $this->getSchema(),
+            $this->in,
+            $parameter->style,
+        );
+
+        $this->explode = $parameter->explode ?? $this->style->defaultExplode();
+    }
+
+    public function getSchema(): Schema
+    {
+        if (isset($this->schema)) {
+            return $this->schema;
+        } else {
+            assert(array_values($this->content)[0]->schema !== null);
+            return array_values($this->content)[0]->schema;
+        }
+    }
+
+    public function hasMediaType(): bool
+    {
+        return !empty($this->content);
+    }
+
+    public function getMediaType(): ?string
+    {
+        return array_key_first($this->content);
+    }
+
+    public function isIdentical(Parameter $other): bool
+    {
+        return $this->name === $other->name && $this->in === $other->in;
+    }
+
+    public function isSimilar(Parameter $other): bool
+    {
+        return $this->name !== $other->name &&
+            mb_strtolower($this->name) === mb_strtolower($other->name);
+    }
+
+    public function canConflictWith(Parameter $other): bool
+    {
+        return ($this->canCauseConflict() && $other->isVulnerableToConflict()) ||
+            ($this->isVulnerableToConflict() && $other->canCauseConflict());
+    }
+
+    private function canCauseConflict(): bool
+    {
+        return $this->in === In::Query &&
+            $this->style === Style::Form &&
+            $this->explode &&
+            $this->getSchema()->canBe(Type::Object);
+    }
+
+    private function isVulnerableToConflict(): bool
+    {
+        /**
+         * @todo once schemas account for minItems and minProperties keywords.
+         * pipeDelimited and spaceDelimited are also vulnerable if:
+         * type:array and minItems <= 1
+         * this is because there would be no delimiter to distinguish it from a form parameter
+         *
+         * form would not be vulnerable if:
+         * explode:false
+         * and...
+         * type:object and minProperties > 1
+         * or ...
+         * type:array and minItems > 1
+         * this is because there would be a delimiter to distinguish it from an exploding parameter
+         */
+
+        return $this->in === In::Query && match ($this->style) {
+            Style::Form => true,
+            Style::PipeDelimited,
+            Style::SpaceDelimited => $this->getSchema()->canBePrimitive(),
+            default => false
+        };
+    }
+
+    private function validateIn(Identifier $identifier, ?string $in): In
+    {
+        if (is_null($in)) {
+            throw InvalidOpenAPI::parameterMissingLocation($identifier);
+        }
+
+        return In::tryFrom($in) ??
+            throw InvalidOpenAPI::parameterInvalidLocation($identifier);
+    }
+
+    private function validateRequired(
+        Identifier $identifier,
+        In $in,
+        ?bool $required
+    ): bool {
+        if ($in === In::Path && $required !== true) {
+            throw InvalidOpenAPI::parameterMissingRequired($identifier);
+        }
+
+        return $required ?? false;
+    }
+
+    private function validateStyle(
+        Identifier $identifier,
+        Schema $schema,
+        In $in,
+        ?string $style
+    ): Style {
+        if (is_null($style)) {
+            return Style::default($in);
+        }
+
+        $style = Style::tryFrom($style) ??
+            throw InvalidOpenAPI::parameterInvalidStyle($identifier);
+
+        $style->isAllowed($in) ?:
+            throw InvalidOpenAPI::parameterIncompatibleStyle($identifier);
+
+        $style !== Style::DeepObject || $schema->canOnlyBe(Type::Object) ?:
+            throw InvalidOpenAPI::deepObjectMustBeObject($identifier);
+
+        if (
+            in_array($style, [Style::SpaceDelimited, Style::PipeDelimited]) &&
+            $schema->canBePrimitive()
+        ) {
+            $this->addWarning(
+                "style:$style->value, is not allowed to be primitive." .
+                'In these instances style:form is recommended.',
+                Warning::UNSUITABLE_STYLE
+            );
+        }
+
+        return $style;
+    }
+
+    /**
+     * @param array<Partial\MediaType> $content
+     * @return array<string,MediaType>
+     */
+    private function validateContent(
+        Identifier $identifier,
+        string $name,
+        array $content,
+    ): array {
+        if (count($content) !== 1) {
+            throw InvalidOpenAPI::parameterContentCanOnlyHaveOneEntry($this->getIdentifier());
+        }
+
+        if (!isset($content[0]->contentType)) {
+            throw InvalidOpenAPI::contentMissingMediaType($identifier);
+        }
+
+        if (!isset($content[0]->schema)) {
+            throw InvalidOpenAPI::mustHaveSchemaXorContent($name);
+        }
+
+        return [
+            $content[0]->contentType => new MediaType(
+                $this->appendedIdentifier($content[0]->contentType),
+                $content[0]
+            ),
+        ];
+    }
+}

--- a/src/ValueObject/Valid/V31/PathItem.php
+++ b/src/ValueObject/Valid/V31/PathItem.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\ValueObject\Valid\V31;
+
+use Membrane\OpenAPIReader\Exception\InvalidOpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid\Enum\Method;
+use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
+use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
+use Membrane\OpenAPIReader\ValueObject\Valid\Warning;
+
+final class PathItem extends Validated
+{
+    /**
+     * @param array<int,Server> $servers
+     *
+     * @param  array<int,Parameter> $parameters
+     * The list MUST NOT include duplicated parameters.
+     * A unique parameter is defined by a combination of a name and location.
+     */
+    private function __construct(
+        Identifier $identifier,
+        public readonly array $servers,
+        public readonly array $parameters,
+        public readonly ?Operation $get,
+        public readonly ?Operation $put,
+        public readonly ?Operation $post,
+        public readonly ?Operation $delete,
+        public readonly ?Operation $options,
+        public readonly ?Operation $head,
+        public readonly ?Operation $patch,
+        public readonly ?Operation $trace,
+    ) {
+        parent::__construct($identifier);
+
+        $this->reviewServers($servers);
+        $this->reviewParameters($parameters);
+        $this->reviewOperations($this->getOperations());
+    }
+
+    public function withoutServers(): PathItem
+    {
+        return new PathItem(
+            $this->getIdentifier(),
+            [new Server(
+                new Identifier($this->getIdentifier()->fromStart() ?? ''),
+                new Partial\Server('/')
+            ),
+            ],
+            $this->parameters,
+            $this->get?->withoutServers(),
+            $this->put?->withoutServers(),
+            $this->post?->withoutServers(),
+            $this->delete?->withoutServers(),
+            $this->options?->withoutServers(),
+            $this->head?->withoutServers(),
+            $this->patch?->withoutServers(),
+            $this->trace?->withoutServers(),
+        );
+    }
+
+    /**
+     * @param array<int,Server> $openAPIServers
+     * If the pathItem does not contain servers, this will be used instead
+     */
+    public static function fromPartial(
+        Identifier $identifier,
+        array $openAPIServers,
+        Partial\PathItem $pathItem,
+    ): PathItem {
+        $servers = self::validateServers(
+            $identifier,
+            $openAPIServers,
+            $pathItem->servers,
+        );
+
+        $parameters = self::validateParameters(
+            $identifier,
+            $pathItem->parameters
+        );
+
+        return new PathItem(
+            identifier: $identifier,
+            servers: $servers,
+            parameters: $parameters,
+            get: self::validateOperation(
+                $identifier,
+                $servers,
+                $parameters,
+                Method::GET,
+                $pathItem->get
+            ),
+            put: self::validateOperation(
+                $identifier,
+                $servers,
+                $parameters,
+                Method::PUT,
+                $pathItem->put
+            ),
+            post: self::validateOperation(
+                $identifier,
+                $servers,
+                $parameters,
+                Method::POST,
+                $pathItem->post
+            ),
+            delete: self::validateOperation(
+                $identifier,
+                $servers,
+                $parameters,
+                Method::DELETE,
+                $pathItem->delete
+            ),
+            options: self::validateOperation(
+                $identifier,
+                $servers,
+                $parameters,
+                Method::OPTIONS,
+                $pathItem->options
+            ),
+            head: self::validateOperation(
+                $identifier,
+                $servers,
+                $parameters,
+                Method::HEAD,
+                $pathItem->head
+            ),
+            patch: self::validateOperation(
+                $identifier,
+                $servers,
+                $parameters,
+                Method::PATCH,
+                $pathItem->patch
+            ),
+            trace: self::validateOperation(
+                $identifier,
+                $servers,
+                $parameters,
+                Method::TRACE,
+                $pathItem->trace
+            ),
+        );
+    }
+
+    /**
+     * Operation "method" keys mapped to Operation values
+     * @return array<string,Operation>
+     */
+    public function getOperations(): array
+    {
+        return array_filter(
+            [
+                Method::GET->value => $this->get,
+                Method::PUT->value => $this->put,
+                Method::POST->value => $this->post,
+                Method::DELETE->value => $this->delete,
+                Method::OPTIONS->value => $this->options,
+                Method::HEAD->value => $this->head,
+                Method::PATCH->value => $this->patch,
+                Method::TRACE->value => $this->trace,
+            ],
+            fn($o) => !is_null($o)
+        );
+    }
+
+    /**
+     * @param array<int,Server> $openAPIServers
+     * @param Partial\Server[] $pathServers
+     * @return array<int,Server>>
+     */
+    private static function validateServers(
+        Identifier $identifier,
+        array $openAPIServers,
+        array $pathServers
+    ): array {
+        if (empty($pathServers)) {
+            return $openAPIServers;
+        }
+
+        return array_values(array_map(
+            fn($s) => new Server($identifier, $s),
+            $pathServers
+        ));
+    }
+
+    /**
+     * @param Server[] $servers
+     */
+    private function reviewServers(array $servers): void
+    {
+        $uniqueURLS = array_unique(array_map(fn($s) => $s->url, $servers));
+        if (count($servers) !== count($uniqueURLS)) {
+            $this->addWarning(
+                'Server URLs are not unique',
+                Warning::IDENTICAL_SERVER_URLS
+            );
+        }
+    }
+
+    /**
+     * @param Partial\Parameter[] $parameters
+     * @return array<int,Parameter>
+     */
+    private static function validateParameters(
+        Identifier $identifier,
+        array $parameters
+    ): array {
+        $result = array_values(array_map(
+            fn($p) => new Parameter($identifier, $p),
+            $parameters
+        ));
+
+        foreach ($result as $index => $parameter) {
+            foreach (array_slice($result, $index + 1) as $otherParameter) {
+                if ($parameter->isIdentical($otherParameter)) {
+                    throw InvalidOpenAPI::duplicateParameters(
+                        $identifier,
+                        $parameter->getIdentifier(),
+                        $otherParameter->getIdentifier(),
+                    );
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<int,Parameter> $parameters
+     */
+    private function reviewParameters(array $parameters): void
+    {
+        foreach ($parameters as $index => $parameter) {
+            foreach (array_slice($parameters, $index + 1) as $other) {
+                if ($parameter->isSimilar($other)) {
+                    $this->addWarning(
+                        <<<TEXT
+                        'This contains confusingly similar parameter names:
+                         $parameter->name
+                         $other->name
+                        TEXT,
+                        Warning::SIMILAR_NAMES
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Server[] $servers
+     * @param Parameter[] $parameters
+     */
+    private static function validateOperation(
+        Identifier $identifier,
+        array $servers,
+        array $parameters,
+        Method $method,
+        ?Partial\Operation $operation
+    ): ?Operation {
+        if (is_null($operation)) {
+            return null;
+        }
+
+        return Operation::fromPartial(
+            $identifier,
+            $servers,
+            $parameters,
+            $method,
+            $operation,
+        );
+    }
+
+    /**
+     * Operation "method" keys mapped to Operation values
+     * @param array<string,Operation> $operations
+     */
+    private function reviewOperations(array $operations): void
+    {
+        if (empty($operations)) {
+            $this->addWarning('No Operations on Path', Warning::EMPTY_PATH);
+        }
+
+        foreach ([Method::OPTIONS, Method::HEAD, Method::TRACE] as $method) {
+            if (isset($operations[$method->value])) {
+                $this->addWarning(
+                    "$method->value is redundant in an OpenAPI Specification.",
+                    Warning::REDUNDANT_METHOD,
+                );
+            }
+        }
+    }
+}

--- a/src/ValueObject/Valid/V31/Schema.php
+++ b/src/ValueObject/Valid/V31/Schema.php
@@ -164,6 +164,12 @@ final class Schema extends Validated implements Valid\Schema
         }
     }
 
+    /** @return Type[] */
+    public function getTypes(): array
+    {
+        return $this->type;
+    }
+
     public function getRelevantMaximum(): ?Limit
     {
         if (isset($this->maximum)) {

--- a/src/ValueObject/Valid/V31/Schema.php
+++ b/src/ValueObject/Valid/V31/Schema.php
@@ -17,8 +17,8 @@ use Membrane\OpenAPIReader\ValueObject\Value;
 
 final class Schema extends Validated implements Valid\Schema
 {
-    /** @var Type[] */
-    public readonly array $type;
+    /** @var Type[]|null */
+    public readonly array|null $type;
     /** @var array<Value>|null  */
     public readonly array|null $enum;
     public readonly Value|null $const;
@@ -167,7 +167,7 @@ final class Schema extends Validated implements Valid\Schema
     /** @return Type[] */
     public function getTypes(): array
     {
-        return $this->type;
+        return $this->type ?? Type::casesForVersion(OpenAPIVersion::Version_3_1);
     }
 
     public function getRelevantMaximum(): ?Limit
@@ -258,12 +258,12 @@ final class Schema extends Validated implements Valid\Schema
 
     /**
      * @param null|string|array<string> $type
-     * @return Type[]
+     * @return Type[]|null
      */
-    private function validateType(Identifier $identifier, null|string|array $type): array
+    private function validateType(Identifier $identifier, null|string|array $type): array|null
     {
         if (is_null($type)) {
-            return [];
+            return null;
         }
 
         if (is_string($type)) {

--- a/src/ValueObject/Valid/V31/Schema.php
+++ b/src/ValueObject/Valid/V31/Schema.php
@@ -260,6 +260,10 @@ final class Schema extends Validated implements Valid\Schema
             $type = [$type];
         }
 
+        if (count($type) !== count(array_unique($type))) {
+            throw InvalidOpenAPI::mustContainUniqueItems($identifier, 'type');
+        }
+
         return array_map(
             fn($t) => Type::tryFromVersion(OpenAPIVersion::Version_3_1, $t) ??
                 throw InvalidOpenAPI::invalidType($identifier, $t),

--- a/src/ValueObject/Valid/V31/Schema.php
+++ b/src/ValueObject/Valid/V31/Schema.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\ValueObject\Valid\V31;
+
+use Membrane\OpenAPIReader\Exception\InvalidOpenAPI;
+use Membrane\OpenAPIReader\OpenAPIVersion;
+use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid\Enum\Type;
+use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
+use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
+use Membrane\OpenAPIReader\ValueObject\Valid\Warning;
+use Membrane\OpenAPIReader\ValueObject\Value;
+
+final class Schema extends Validated
+{
+    /** @var Type[] */
+    public readonly array $type;
+    /** @var array<Value>|null  */
+    public readonly array|null $enum;
+    public readonly Value|null $const;
+
+    public readonly float|int|null $multipleOf;
+    public readonly float|int|null $exclusiveMaximum;
+    public readonly float|int|null $exclusiveMinimum;
+    public readonly float|int|null $maximum;
+    public readonly float|int|null $minimum;
+
+    public readonly int|null $maxLength;
+    public readonly int $minLength;
+    public readonly string|null $pattern;
+
+    public readonly int|null $maxItems;
+    public readonly int $minItems;
+    public readonly bool $uniqueItems;
+    public readonly int|null $maxContains;
+    public readonly int $minContains;
+
+    public readonly int|null $maxProperties;
+    public readonly int $minProperties;
+    /** @var array<string>  */
+    public readonly array $required;
+    /** @var array<array<string>> */
+    public readonly array $dependentRequired;
+
+    /** @var non-empty-array<Schema>|null */
+    public readonly array|null $allOf;
+    /** @var non-empty-array<Schema>|null */
+    public readonly ?array $anyOf;
+    /** @var non-empty-array<Schema>|null */
+    public readonly array|null $oneOf;
+    public readonly Schema|null $not;
+
+    public readonly Schema|null $if;
+    public readonly Schema|null $then;
+    public readonly Schema|null $else;
+    /** @var array<string,Schema> */
+    public readonly array $dependentSchemas;
+
+    /** @var array<Schema> */
+    public readonly array $prefixItems;
+    public readonly Schema|null $items; //ommited should be empty Schema, but we require types.
+    public readonly Schema|null $contains;
+
+    /** @var array<string,Schema> */
+    public readonly array $properties;
+    /** @var array<string,Schema> */
+    public readonly array $patternProperties;
+    public readonly Schema|bool $additionalProperties; //ommited should be empty Schema, but we require types.
+    public readonly Schema|bool $propertyNames; //ommited should be empty Schema, but we require types.
+
+    public readonly Schema|bool $unevaluatedItems; //ommited should be empty Schema, but we require types.
+    public readonly Schema|bool $unevaluatedProperties; //ommited should be empty Schema, but we require types.
+
+    /** @var Type[] */
+    private readonly array $typesItCanBe;
+
+    public function __construct(
+        Identifier $identifier,
+        Partial\Schema $schema
+    ) {
+        parent::__construct($identifier);
+        $this->type = $this->validateType($this->getIdentifier(), $schema->type);
+        $this->enum = $schema->enum;
+        $this->const = $schema->const;
+
+        $this->multipleOf = $this->validatePositiveNumber('multipleOf', $schema->multipleOf);
+        $this->maximum = $schema->maximum;
+        $this->exclusiveMaximum = $this->validateExclusiveMinMax('exclusiveMaximum', $schema->exclusiveMaximum);
+        $this->minimum = $schema->minimum;
+        $this->exclusiveMinimum = $this->validateExclusiveMinMax('exclusiveMinimum', $schema->exclusiveMinimum);
+
+        $this->maxLength = $this->validateNonNegativeInteger('maxLength', $schema->maxLength);
+        $this->minLength = $this->validateNonNegativeInteger('minLength', $schema->minLength) ?? 0;
+        $this->pattern = $schema->pattern;
+
+        $this->maxItems = $this->validateNonNegativeInteger('maxItems', $schema->maxItems);
+        $this->minItems = $this->validateNonNegativeInteger('minItems', $schema->minItems) ?? 0;
+        $this->uniqueItems = $schema->uniqueItems;
+        $this->maxContains = $this->validateNonNegativeInteger('maxContains', $schema->maxContains);
+        $this->minContains = $this->validateNonNegativeInteger('minContains', $schema->minContains) ?? 1;
+
+        $this->maxProperties = $this->validateNonNegativeInteger('maxProperties', $schema->maxProperties);
+        $this->minProperties = $this->validateNonNegativeInteger('minProperties', $schema->minProperties) ?? 0;
+        $this->required = $this->validateRequired($schema->required);
+        $this->dependentRequired = $this->validateDependentRequired($schema->dependentRequired);
+
+        $this->allOf = $this->validateNonEmptySubSchemas('allOf', $schema->allOf);
+        $this->anyOf = $this->validateNonEmptySubSchemas('anyOf', $schema->anyOf);
+        $this->oneOf = $this->validateNonEmptySubSchemas('oneOf', $schema->oneOf);
+        $this->not = isset($schema->not) ?
+            new Schema($this->getIdentifier()->append('not'), $schema->not) :
+            null;
+
+        $this->if = isset($schema->if) ?
+            new Schema($this->getIdentifier()->append('if'), $schema->if) :
+            null;
+        $this->then = isset($schema->then) ?
+            new Schema($this->getIdentifier()->append('then'), $schema->then) :
+            null;
+        $this->else = isset($schema->else) ?
+            new Schema($this->getIdentifier()->append('else'), $schema->else) :
+            null;
+        $this->dependentSchemas = $this->validateSubSchemas('dependentSchemas', $schema->dependentSchemas);
+
+        $this->prefixItems = $this->validateSubSchemas('prefixItems', $schema->prefixItems);
+        $this->items = $this->validateItems($schema->items);
+        $this->contains = isset($schema->contains) ?
+            new Schema($this->getIdentifier()->append('contains'), $schema->contains) :
+            null;
+
+        $this->properties = $this->validateSubSchemas('properties', $schema->properties);
+        $this->patternProperties = $this->validateSubSchemas('patternProperties', $schema->patternProperties);
+        $this->additionalProperties = is_bool($schema->additionalProperties) ?
+            $schema->additionalProperties :
+            new Schema($this->getIdentifier()->append('additionalProperties'), $schema->additionalProperties);
+        $this->propertyNames = is_bool($schema->propertyNames) ?
+            $schema->propertyNames :
+            new Schema($this->getIdentifier()->append('additionalProperties'), $schema->propertyNames);
+
+        $this->unevaluatedItems = is_bool($schema->unevaluatedItems) ?
+            $schema->unevaluatedItems :
+            new Schema($this->getIdentifier()->append('additionalProperties'), $schema->unevaluatedItems);
+
+        $this->unevaluatedProperties = is_bool($schema->unevaluatedProperties) ?
+            $schema->unevaluatedProperties :
+            new Schema($this->getIdentifier()->append('additionalProperties'), $schema->unevaluatedProperties);
+
+        $this->typesItCanBe = array_map(fn($t) => Type::from($t), $this
+            ->typesItCanBe());
+
+        if (empty($this->typesItCanBe)) {
+            $this->addWarning(
+                'no data type can satisfy this schema',
+                Warning::IMPOSSIBLE_SCHEMA
+            );
+        }
+    }
+
+    public function canBe(Type $type): bool
+    {
+        return in_array($type, $this->typesItCanBe);
+    }
+
+    public function canOnlyBe(Type $type): bool
+    {
+        return [$type] === $this->typesItCanBe;
+    }
+
+    public function canBePrimitive(): bool
+    {
+        foreach ($this->typesItCanBe as $typeItCanBe) {
+            if ($typeItCanBe->isPrimitive()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return string[] */
+    private function typesItCanBe(): array
+    {
+        $possibilities = [Type::valuesForVersion(OpenAPIVersion::Version_3_0)];
+
+        if (!empty($this->type)) {
+            $possibilities[] = array_map(fn($t) => $t->value, $this->type);
+        }
+
+        if (!empty($this->allOf)) {
+            $possibilities[] = array_intersect(...array_map(
+                fn($s) => $s->typesItCanBe(),
+                $this->allOf,
+            ));
+        }
+
+        if (!empty($this->anyOf)) {
+            $possibilities[] = array_unique(array_merge(...array_map(
+                fn($s) => $s->typesItCanBe(),
+                $this->anyOf
+            )));
+        }
+
+        if (!empty($this->oneOf)) {
+            $possibilities[] = array_unique(array_merge(...array_map(
+                fn($s) => $s->typesItCanBe(),
+                $this->oneOf
+            )));
+        }
+
+        return array_values(array_intersect(...$possibilities));
+    }
+
+    /**
+     * @param null|string|array<string> $type
+     * @return Type[]
+     */
+    private function validateType(Identifier $identifier, null|string|array $type): array
+    {
+        if (is_null($type)) {
+            return [];
+        }
+
+        if (is_string($type)) {
+            $type = [$type];
+        }
+
+        return array_map(
+            fn($t) => Type::tryFromVersion(OpenAPIVersion::Version_3_1, $t) ??
+                throw InvalidOpenAPI::invalidType($identifier, $t),
+            $type
+        );
+    }
+
+    private function validateExclusiveMinMax(
+        string $keyword,
+        bool|float|int|null $exclusiveMinMax,
+    ): float|int|null {
+        if (is_bool($exclusiveMinMax)) {
+            throw InvalidOpenAPI::boolExclusiveMinMaxIn31($this->getIdentifier(), $keyword);
+        }
+
+        return $exclusiveMinMax;
+    }
+
+    private function validatePositiveNumber(
+        string $keyword,
+        float|int|null $value
+    ): float|int|null {
+        if ($value !== null && $value <= 0) {
+            throw InvalidOpenAPI::keywordMustBeStrictlyPositiveNumber($this->getIdentifier(), $keyword);
+        }
+
+        return $value;
+    }
+
+    private function validateNonNegativeInteger(
+        string $keyword,
+        int|null $value
+    ): int|null {
+        if ($value !== null && $value < 0) {
+            throw InvalidOpenAPI::keywordMustBeNegativeInteger($this->getIdentifier(), $keyword);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string>|null $value
+     * @return array<string>
+     */
+    private function validateRequired(array|null $value): array
+    {
+        $value ??= [];
+
+        if (count($value) !== count(array_unique($value))) {
+            throw InvalidOpenAPI::mustContainUniqueItems($this->getIdentifier(), 'required');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<array<string>>|null $value
+     * @return array<array<string>>
+     */
+    private function validateDependentRequired(array|null $value): array
+    {
+        $value ??= [];
+
+        foreach ($value as $subValue) {
+            if (count($subValue) !== count(array_unique($subValue))) {
+                throw InvalidOpenAPI::mustContainUniqueItems($this->getIdentifier(), 'dependentRequired');
+            }
+        }
+
+
+
+        return $value;
+    }
+
+    /**
+     * @param null|array<Partial\Schema> $subSchemas
+     * @return null|non-empty-array<Schema>
+     */
+    private function validateNonEmptySubSchemas(string $keyword, ?array $subSchemas): ?array
+    {
+        if (!isset($subSchemas)) {
+            return null;
+        }
+
+        if (empty($subSchemas)) {
+            throw InvalidOpenAPI::mustBeNonEmpty($this->getIdentifier(), $keyword);
+        }
+
+        $result = [];
+        foreach ($subSchemas as $index => $subSchema) {
+            $result[$index] = new Schema(
+                $this->getIdentifier()->append("$keyword($index)"),
+                $subSchema
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param null|array<Partial\Schema> $subSchemas
+     * @return array<Schema>
+     */
+    private function validateSubSchemas(string $keyword, ?array $subSchemas): array
+    {
+        $subSchemas ??= [];
+
+        $result = [];
+        foreach ($subSchemas as $index => $subSchema) {
+            $result[$index] = new Schema(
+                $this->getIdentifier()->append("$keyword($index)"),
+                $subSchema
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<Partial\Schema>|Partial\Schema|Partial\Schema|null $items
+     */
+    private function validateItems(array|Partial\Schema|null $items): Schema|null
+    {
+        if (is_array($items)) {
+            throw InvalidOpenAPI::arrayItemsIn31($this->getIdentifier());
+        }
+
+        if (is_null($items)) {
+            return $items;
+        }
+
+        return new Schema($this->getIdentifier()->append('items'), $items);
+    }
+}

--- a/src/ValueObject/Valid/V31/Schema.php
+++ b/src/ValueObject/Valid/V31/Schema.php
@@ -77,6 +77,9 @@ final class Schema extends Validated implements Valid\Schema
 
     public readonly string|null $format;
 
+    public readonly string|null $title;
+    public readonly string|null $description;
+
     /** @var Type[] */
     private readonly array $typesItCanBe;
 
@@ -152,6 +155,9 @@ final class Schema extends Validated implements Valid\Schema
             new Schema($this->getIdentifier()->append('additionalProperties'), $schema->unevaluatedProperties);
 
         $this->format = $schema->format;
+
+        $this->title = $schema->title;
+        $this->description = $schema->description;
 
         $this->typesItCanBe = array_map(fn($t) => Type::from($t), $this
             ->typesItCanBe());

--- a/src/ValueObject/Valid/V31/Schema.php
+++ b/src/ValueObject/Valid/V31/Schema.php
@@ -75,6 +75,8 @@ final class Schema extends Validated implements Valid\Schema
     public readonly Schema|bool $unevaluatedItems; //ommited should be empty Schema, but we require types.
     public readonly Schema|bool $unevaluatedProperties; //ommited should be empty Schema, but we require types.
 
+    public readonly string|null $format;
+
     /** @var Type[] */
     private readonly array $typesItCanBe;
 
@@ -148,6 +150,8 @@ final class Schema extends Validated implements Valid\Schema
         $this->unevaluatedProperties = is_bool($schema->unevaluatedProperties) ?
             $schema->unevaluatedProperties :
             new Schema($this->getIdentifier()->append('additionalProperties'), $schema->unevaluatedProperties);
+
+        $this->format = $schema->format;
 
         $this->typesItCanBe = array_map(fn($t) => Type::from($t), $this
             ->typesItCanBe());

--- a/src/ValueObject/Valid/V31/Schema.php
+++ b/src/ValueObject/Valid/V31/Schema.php
@@ -6,14 +6,16 @@ namespace Membrane\OpenAPIReader\ValueObject\Valid\V31;
 
 use Membrane\OpenAPIReader\Exception\InvalidOpenAPI;
 use Membrane\OpenAPIReader\OpenAPIVersion;
+use Membrane\OpenAPIReader\ValueObject\Limit;
 use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid;
 use Membrane\OpenAPIReader\ValueObject\Valid\Enum\Type;
 use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
 use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
 use Membrane\OpenAPIReader\ValueObject\Valid\Warning;
 use Membrane\OpenAPIReader\ValueObject\Value;
 
-final class Schema extends Validated
+final class Schema extends Validated implements Valid\Schema
 {
     /** @var Type[] */
     public readonly array $type;
@@ -156,6 +158,38 @@ final class Schema extends Validated
                 Warning::IMPOSSIBLE_SCHEMA
             );
         }
+    }
+
+    public function getRelevantMaximum(): ?Limit
+    {
+        if (isset($this->maximum)) {
+            if (isset($this->exclusiveMaximum) && $this->exclusiveMaximum <= $this->maximum) {
+                return new Limit($this->exclusiveMaximum, true);
+            }
+            return new Limit($this->maximum, false);
+        }
+
+        if (isset($this->exclusiveMaximum)) {
+            return new Limit($this->exclusiveMaximum, true);
+        }
+
+        return null;
+    }
+
+    public function getRelevantMinimum(): ?Limit
+    {
+        if (isset($this->minimum)) {
+            if (isset($this->exclusiveMinimum) && $this->exclusiveMinimum >= $this->minimum) {
+                return new Limit($this->exclusiveMinimum, true);
+            }
+            return new Limit($this->minimum, false);
+        }
+
+        if (isset($this->exclusiveMinimum)) {
+            return new Limit($this->exclusiveMinimum, true);
+        }
+
+        return null;
     }
 
     public function canBe(Type $type): bool

--- a/src/ValueObject/Valid/V31/Server.php
+++ b/src/ValueObject/Valid/V31/Server.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\ValueObject\Valid\V31;
+
+use Membrane\OpenAPIReader\Exception\InvalidOpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
+use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
+use Membrane\OpenAPIReader\ValueObject\Valid\Warning;
+
+final class Server extends Validated
+{
+    /**
+     * REQUIRED
+     */
+    public readonly string $url;
+
+    /**
+     * When the url has a variable named in {brackets}
+     * This array MUST contain the definition of the corresponding variable.
+     *
+     * The name of the variable is mapped to the Server Variable Object
+     * @var array<string,ServerVariable>
+     */
+    public readonly array $variables;
+
+    public function __construct(
+        Identifier $parentIdentifier,
+        Partial\Server $server,
+    ) {
+        if (!isset($server->url)) {
+            throw InvalidOpenAPI::serverMissingUrl($parentIdentifier);
+        }
+
+        parent::__construct($parentIdentifier->append($server->url));
+
+        $this->url = $this->validateUrl($parentIdentifier, $server->url);
+
+        $this->variables = $this->validateVariables(
+            $this->getIdentifier(),
+            $this->getVariableNames(),
+            $server->variables,
+        );
+    }
+
+    /**
+     * Returns the list of variable names in order of appearance within the URL.
+     * @return array<int, string>
+     */
+    public function getVariableNames(): array
+    {
+        preg_match_all('#{[^/]+}#', $this->url, $result);
+
+        return array_map(fn($v) => trim($v, '{}'), $result[0]);
+    }
+
+    /**
+     * Returns the regex of the URL
+     */
+    public function getPattern(): string
+    {
+        $regex = preg_replace('#{[^/]+}#', '([^/]+)', $this->url);
+        assert(is_string($regex));
+        return $regex;
+    }
+
+    private function validateUrl(Identifier $identifier, string $url): string
+    {
+        $characters = str_split($url);
+
+        $insideVariable = false;
+        foreach ($characters as $character) {
+            if ($character === '{') {
+                if ($insideVariable) {
+                    throw InvalidOpenAPI::urlNestedVariable(
+                        $identifier->append($url)
+                    );
+                }
+                $insideVariable = true;
+            } elseif ($character === '}') {
+                if (!$insideVariable) {
+                    throw InvalidOpenAPI::urlLiteralClosingBrace(
+                        $identifier->append($url)
+                    );
+                }
+                $insideVariable = false;
+            }
+        }
+
+        if ($insideVariable) {
+            throw InvalidOpenAPI::urlUnclosedVariable($identifier->append($url));
+        }
+
+        if (str_ends_with($url, '/') && $url !== '/') {
+            $this->addWarning(
+                'paths begin with a forward slash, so servers need not end in one',
+                Warning::REDUNDANT_FORWARD_SLASH,
+            );
+        }
+
+        return rtrim($url, '/');
+    }
+
+    /**
+     * @param array<int,string> $UrlVariableNames
+     * @param Partial\ServerVariable[] $variables
+     * @return array<string,ServerVariable>
+     */
+    private function validateVariables(
+        Identifier $identifier,
+        array $UrlVariableNames,
+        array $variables,
+    ): array {
+        $result = [];
+        foreach ($variables as $variable) {
+            if (!isset($variable->name)) {
+                throw InvalidOpenAPI::serverVariableMissingName($identifier);
+            }
+
+            if (!in_array($variable->name, $UrlVariableNames)) {
+                $this->addWarning(
+                    sprintf(
+                        '"variables" defines "%s" which is not found in "url".',
+                        $variable->name
+                    ),
+                    Warning::REDUNDANT_VARIABLE
+                );
+
+                continue;
+            }
+
+            $result[$variable->name] = new ServerVariable(
+                $identifier->append($variable->name),
+                $variable
+            );
+        }
+
+        $undefined = array_diff($UrlVariableNames, array_keys($result));
+        if (!empty($undefined)) {
+            throw InvalidOpenAPI::serverHasUndefinedVariables(
+                $identifier,
+                ...$undefined,
+            );
+        }
+
+        return $result;
+    }
+}

--- a/src/ValueObject/Valid/V31/ServerVariable.php
+++ b/src/ValueObject/Valid/V31/ServerVariable.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\ValueObject\Valid\V31;
+
+use Membrane\OpenAPIReader\Exception\InvalidOpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
+use Membrane\OpenAPIReader\ValueObject\Valid\Validated;
+use Membrane\OpenAPIReader\ValueObject\Valid\Warning;
+
+final class ServerVariable extends Validated
+{
+    /** REQUIRED */
+    public readonly string $default;
+
+    /**
+     * If not null:
+     * - It SHOULD NOT be empty
+     * - The "default" value SHOULD be contained within this list
+     * @var string[]
+     */
+    public readonly ?array $enum;
+
+    public function __construct(
+        Identifier $identifier,
+        Partial\ServerVariable $serverVariable,
+    ) {
+        parent::__construct($identifier);
+
+        if (!isset($serverVariable->default)) {
+            throw InvalidOpenAPI::serverVariableMissingDefault($identifier);
+        }
+
+        $this->default = $serverVariable->default;
+
+        if (isset($serverVariable->enum)) {
+            if (empty($serverVariable->enum)) {
+                $this->addWarning(
+                    'If "enum" is defined, it SHOULD NOT be empty',
+                    Warning::EMPTY_ENUM,
+                );
+            }
+
+            if (!in_array($serverVariable->default, $serverVariable->enum)) {
+                $this->addWarning(
+                    'If "enum" is defined, the "default" SHOULD exist within it.',
+                    Warning::IMPOSSIBLE_DEFAULT
+                );
+            }
+        }
+
+        $this->enum = $serverVariable->enum;
+    }
+}

--- a/tests/MembraneReaderTest.php
+++ b/tests/MembraneReaderTest.php
@@ -61,15 +61,6 @@ class MembraneReaderTest extends TestCase
     }
 
     #[Test]
-    #[TestDox('Currently only V3.0.X Membrane Objects are supported')]
-    public function itCurrentlySupportsOnlyV30(): void
-    {
-        self::expectExceptionObject(CannotSupport::membraneReaderOnlySupportsv30());
-
-        new MembraneReader([OpenAPIVersion::Version_3_1]);
-    }
-
-    #[Test]
     public function itCannotReadFilesItCannotFind(): void
     {
         $filePath = vfsStream::setup()->url() . '/openapi';

--- a/tests/MembraneReaderTest.php
+++ b/tests/MembraneReaderTest.php
@@ -338,6 +338,20 @@ class MembraneReaderTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
+    #[Test]
+    #[DataProvider('provideRealExamples')]
+    public function itReadsRealExamples(OpenAPI $expected, string $filepath): void
+    {
+        $sut = new MembraneReader([
+            OpenAPIVersion::Version_3_0,
+            OpenAPIVersion::Version_3_1,
+        ]);
+
+        $actual = $sut->readFromAbsoluteFilePath($filepath);
+
+        self::assertEquals($expected, $actual);
+    }
+
     public static function provideInvalidFormatting(): Generator
     {
         yield 'Empty string to be interpreted as json' => ['', FileFormat::Json];
@@ -672,5 +686,14 @@ class MembraneReaderTest extends TestCase
             OpenAPIProvider::detailedV30MembraneObject(),
             OpenAPIProvider::detailedV30String(),
         ];
+    }
+
+    public static function provideRealExamples(): Generator
+    {
+        yield '3.1 Train Travel API' => [
+            OpenAPIProvider::minimalV30MembraneObject(),
+            __DIR__ . '/fixtures/train-travel-api.yaml',
+        ];
+
     }
 }

--- a/tests/MembraneReaderTest.php
+++ b/tests/MembraneReaderTest.php
@@ -7,6 +7,7 @@ namespace Membrane\OpenAPIReader\Tests;
 use cebe\{openapi\exceptions as CebeException};
 use Generator;
 use Membrane\OpenAPIReader\Tests\Fixtures\ProvidesTrainTravelApi;
+use Membrane\OpenAPIReader\Tests\Fixtures\Helper\V31OpenAPIProvider;
 use Membrane\OpenAPIReader\{FileFormat, OpenAPIVersion};
 use Membrane\OpenAPIReader\Exception\{CannotRead, CannotSupport, InvalidOpenAPI};
 use Membrane\OpenAPIReader\Factory\V30\FromCebe;
@@ -319,12 +320,17 @@ class MembraneReaderTest extends TestCase
     }
 
     #[Test, DataProvider('provideOpenAPIToRead')]
-    public function itReadsFromFile(OpenAPI $expected, string $openApi): void
-    {
+    public function itReadsFromFile(
+        Valid\V30\OpenAPI|Valid\V31\OpenAPI $expected,
+        string $openApi
+    ): void {
         $filePath = vfsStream::setup()->url() . '/openapi.json';
         file_put_contents($filePath, $openApi);
 
-        $sut = new MembraneReader([OpenAPIVersion::Version_3_0]);
+        $sut = new MembraneReader([
+            OpenAPIVersion::Version_3_0,
+            OpenAPIVersion::Version_3_1,
+        ]);
 
         $actual = $sut->readFromAbsoluteFilePath($filePath, FileFormat::Json);
 
@@ -332,9 +338,14 @@ class MembraneReaderTest extends TestCase
     }
 
     #[Test, DataProvider('provideOpenAPIToRead')]
-    public function itReadsFromString(OpenAPI $expected, string $openApi): void
-    {
-        $sut = new MembraneReader([OpenAPIVersion::Version_3_0]);
+    public function itReadsFromString(
+        Valid\V30\OpenAPI|Valid\V31\OpenAPI $expected,
+        string $openApi
+    ): void {
+        $sut = new MembraneReader([
+            OpenAPIVersion::Version_3_0,
+            OpenAPIVersion::Version_3_1,
+        ]);
 
         $actual = $sut->readFromString($openApi, FileFormat::Json);
 
@@ -686,14 +697,24 @@ class MembraneReaderTest extends TestCase
 
     public static function provideOpenAPIToRead(): Generator
     {
-        yield 'minimal OpenAPI' => [
+        yield 'minimal V30' => [
             OpenAPIProvider::minimalV30MembraneObject(),
             OpenAPIProvider::minimalV30String(),
         ];
 
-        yield 'detailed OpenAPI' => [
+        yield 'detailed V30' => [
             OpenAPIProvider::detailedV30MembraneObject(),
             OpenAPIProvider::detailedV30String(),
+        ];
+
+        yield 'minimal V31' => [
+            V31OpenAPIProvider::minimalV31MembraneObject(),
+            V31OpenAPIProvider::minimalV31String(),
+        ];
+
+        yield 'detailed V31' => [
+            V31OpenAPIProvider::detailedV31MembraneObject(),
+            V31OpenAPIProvider::detailedV31String(),
         ];
     }
 }

--- a/tests/fixtures/Helper/PartialHelper.php
+++ b/tests/fixtures/Helper/PartialHelper.php
@@ -160,6 +160,8 @@ final class PartialHelper
         array|null $oneOf = null,
         Schema|null $not = null,
         string|null $format = null,
+        string|null $title = null,
+        string|null $description = null,
     ): Schema {
         return new Schema(
             type: $type,
@@ -187,6 +189,8 @@ final class PartialHelper
             items: $items,
             properties: $properties,
             format: $format,
+            title: $title,
+            description: $description,
         );
     }
 }

--- a/tests/fixtures/Helper/V31OpenAPIProvider.php
+++ b/tests/fixtures/Helper/V31OpenAPIProvider.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\Tests\Fixtures\Helper;
+
+use cebe\openapi\spec as Cebe;
+use Membrane\OpenAPIReader\ValueObject\Valid\V30\OpenAPI;
+
+final class OpenAPIProvider
+{
+    /**
+     * This will return a "minimal" JSON string OpenAPI
+     * Functions prefixed with "minimalV30" return equivalent OpenAPI
+     */
+    public static function minimalV30String(): string
+    {
+        $string = json_encode([
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'My Minimal OpenAPI', 'version' => '1.0.0'],
+            'paths' => []
+        ]);
+
+        assert(is_string($string));
+
+        return $string;
+    }
+
+    /**
+     * This will return a "minimal" cebe library, OpenAPI object
+     * Functions prefixed with "minimalV30" return equivalent OpenAPI
+     */
+    public static function minimalV30CebeObject(): Cebe\OpenApi
+    {
+        return new Cebe\OpenApi([
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'My Minimal OpenAPI', 'version' => '1.0.0'],
+            'paths' => []
+        ]);
+    }
+
+    /**
+     * This will return a "minimal" Membrane OpenAPI object
+     * Functions prefixed with "minimalV30" return equivalent OpenAPI
+     */
+    public static function minimalV30MembraneObject(): OpenAPI
+    {
+        return OpenAPI::fromPartial(PartialHelper::createOpenAPI(
+            openapi: '3.0.0',
+            title: 'My Minimal OpenAPI',
+            version: '1.0.0',
+            paths: []
+        ));
+    }
+
+    /**
+     * This will return a "detailed" JSON string OpenAPI
+     * Functions prefixed with "detailedV30" return equivalent OpenAPI
+     */
+    public static function detailedV30String(): string
+    {
+        $string = json_encode([
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'My Detailed OpenAPI', 'version' => '1.0.1'],
+            'servers' => [
+                [
+                    'url' => 'https://server.net/{version}',
+                    'variables' => [
+                        'version' => [
+                            'default' => '2.1',
+                            'enum' => ['2.0', '2.1', '2.2',]
+                        ]
+                    ]
+                ]
+            ],
+            'paths' => [
+                '/first' => [
+                    'parameters' => [
+                        [
+                            'name' => 'limit',
+                            'in' => 'query',
+                            'required' => false,
+                            'schema' => ['type' => 'integer']
+                        ]
+                    ],
+                    'get' => [
+                        'operationId' => 'first-get',
+                        'parameters' => [
+                            [
+                                'name' => 'pet',
+                                'in' => 'header',
+                                'required' => true,
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            'allOf' => [
+                                                ['type' => 'integer'],
+                                                ['type' => 'number'],
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ],
+                        'responses' => [
+                            '200' => [
+                                'description' => 'Successful Response'
+                            ]
+                        ]
+                    ]
+                ],
+                '/second' => [
+                    'servers' => [
+                        ['url' => 'https://second-server.co.uk']
+                    ],
+                    'parameters' => [
+                        [
+                            'name' => 'limit',
+                            'in' => 'query',
+                            'required' => false,
+                            'schema' => ['type' => 'integer']
+                        ]
+                    ],
+                    'get' => [
+                        'operationId' => 'second-get',
+                        'parameters' => [
+                            [
+                                'name' => 'pet',
+                                'in' => 'header',
+                                'required' => true,
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            'allOf' => [
+                                                ['type' => 'integer'],
+                                                ['type' => 'number']
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ],
+                        'responses' => [
+                            '200' => [
+                                'description' => 'Successful Response'
+                            ]
+                        ]
+                    ],
+                    'put' => [
+                        'operationId' => 'second-put',
+                        'servers' => [
+                            ['url' => 'https://second-put.com']
+                        ],
+                        'parameters' => [[
+                            'name' => 'user',
+                            'in' => 'cookie',
+                            'schema' => ['type' => 'object'],
+                        ]],
+                        'responses' => [
+                            '200' => [
+                                'description' => 'Successful Response'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+        ]);
+
+        assert(is_string($string));
+
+        return $string;
+    }
+
+    /**
+     * This will return a "detailed" cebe library, OpenAPI object
+     * Functions prefixed with "detailedV30" return equivalent OpenAPI
+     */
+    public static function detailedV30CebeObject(): Cebe\OpenApi
+    {
+        return new Cebe\OpenApi(json_decode(self::detailedV30String(), true));
+    }
+
+    /**
+     * This will return a "detailed" Membrane\OpenAPIReader\ValueObject\Valid\V30\OpenAPI object
+     * Functions prefixed with "detailedV30" return equivalent OpenAPI
+     */
+    public static function detailedV30MembraneObject(): OpenAPI
+    {
+        return OpenAPI::fromPartial(PartialHelper::createOpenAPI(
+            openapi: '3.0.0',
+            title: 'My Detailed OpenAPI',
+            version: '1.0.1',
+            servers: [
+                PartialHelper::createServer(
+                    url: 'https://server.net/{version}',
+                    variables: [
+                        PartialHelper::createServerVariable(
+                            name: 'version',
+                            default: '2.1',
+                            enum: ['2.0', '2.1', '2.2'],
+                        ),
+                    ]
+                ),
+            ],
+            paths: [
+                PartialHelper::createPathItem(
+                    path: '/first',
+                    parameters: [
+                        PartialHelper::createParameter(
+                            name: 'limit',
+                            in: 'query',
+                            required: false,
+                            schema: PartialHelper::createSchema(
+                                type: 'integer'
+                            )
+                        ),
+                    ],
+                    get: PartialHelper::createOperation(
+                        operationId: 'first-get',
+                        parameters: [
+                            PartialHelper::createParameter(
+                                name: 'pet',
+                                in: 'header',
+                                required: true,
+                                schema: null,
+                                content: [
+                                    PartialHelper::createMediaType(
+                                        mediaType: 'application/json',
+                                        schema: PartialHelper::createSchema(
+                                            allOf: [
+                                                PartialHelper::createSchema(
+                                                    type: 'integer'
+                                                ),
+                                                PartialHelper::createSchema(
+                                                    type: 'number'
+                                                )
+                                            ]
+                                        )
+                                    )
+                                ]
+                            )
+                        ]
+                    )
+                ),
+                PartialHelper::createPathItem(
+                    path: '/second',
+                    servers: [
+                        PartialHelper::createServer(
+                            url: 'https://second-server.co.uk'
+                        ),
+                    ],
+                    parameters: [
+                        PartialHelper::createParameter(
+                            name: 'limit',
+                            in: 'query',
+                            required: false,
+                            schema: PartialHelper::createSchema(
+                                type: 'integer'
+                            )
+                        ),
+                    ],
+                    get: PartialHelper::createOperation(
+                        operationId: 'second-get',
+                        parameters: [
+                            PartialHelper::createParameter(
+                                name: 'pet',
+                                in: 'header',
+                                required: true,
+                                schema: null,
+                                content: [
+                                    PartialHelper::createMediaType(
+                                        mediaType: 'application/json',
+                                        schema: PartialHelper::createSchema(
+                                            allOf: [
+                                                PartialHelper::createSchema(
+                                                    type: 'integer'
+                                                ),
+                                                PartialHelper::createSchema(
+                                                    type: 'number'
+                                                )
+                                            ]
+                                        )
+                                    )
+                                ]
+                            )
+                        ]
+                    ),
+                    put: PartialHelper::createOperation(
+                        operationId: 'second-put',
+                        servers: [
+                            PartialHelper::createServer(url: 'https://second-put.com')
+                        ],
+                        parameters: [
+                            PartialHelper::createParameter(
+                                name: 'user',
+                                in: 'cookie',
+                                required: false,
+                                schema: PartialHelper::createSchema(
+                                    type: 'object'
+                                )
+                            )
+                        ]
+                    )
+                )
+            ]
+        ));
+    }
+}

--- a/tests/fixtures/Helper/V31OpenAPIProvider.php
+++ b/tests/fixtures/Helper/V31OpenAPIProvider.php
@@ -4,19 +4,18 @@ declare(strict_types=1);
 
 namespace Membrane\OpenAPIReader\Tests\Fixtures\Helper;
 
-use cebe\openapi\spec as Cebe;
-use Membrane\OpenAPIReader\ValueObject\Valid\V30\OpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Valid\V31\OpenAPI;
 
-final class OpenAPIProvider
+final class V31OpenAPIProvider
 {
     /**
      * This will return a "minimal" JSON string OpenAPI
-     * Functions prefixed with "minimalV30" return equivalent OpenAPI
+     * Functions prefixed with "minimalV31" return equivalent OpenAPI
      */
-    public static function minimalV30String(): string
+    public static function minimalV31String(): string
     {
         $string = json_encode([
-            'openapi' => '3.0.0',
+            'openapi' => '3.1.0',
             'info' => ['title' => 'My Minimal OpenAPI', 'version' => '1.0.0'],
             'paths' => []
         ]);
@@ -27,26 +26,13 @@ final class OpenAPIProvider
     }
 
     /**
-     * This will return a "minimal" cebe library, OpenAPI object
-     * Functions prefixed with "minimalV30" return equivalent OpenAPI
-     */
-    public static function minimalV30CebeObject(): Cebe\OpenApi
-    {
-        return new Cebe\OpenApi([
-            'openapi' => '3.0.0',
-            'info' => ['title' => 'My Minimal OpenAPI', 'version' => '1.0.0'],
-            'paths' => []
-        ]);
-    }
-
-    /**
      * This will return a "minimal" Membrane OpenAPI object
-     * Functions prefixed with "minimalV30" return equivalent OpenAPI
+     * Functions prefixed with "minimalV31" return equivalent OpenAPI
      */
-    public static function minimalV30MembraneObject(): OpenAPI
+    public static function minimalV31MembraneObject(): OpenAPI
     {
-        return OpenAPI::fromPartial(PartialHelper::createOpenAPI(
-            openapi: '3.0.0',
+        return OpenAPI::fromPartial(V31PartialHelper::createOpenAPI(
+            openapi: '3.1.0',
             title: 'My Minimal OpenAPI',
             version: '1.0.0',
             paths: []
@@ -55,12 +41,12 @@ final class OpenAPIProvider
 
     /**
      * This will return a "detailed" JSON string OpenAPI
-     * Functions prefixed with "detailedV30" return equivalent OpenAPI
+     * Functions prefixed with "detailedV31" return equivalent OpenAPI
      */
-    public static function detailedV30String(): string
+    public static function detailedV31String(): string
     {
         $string = json_encode([
-            'openapi' => '3.0.0',
+            'openapi' => '3.1.0',
             'info' => ['title' => 'My Detailed OpenAPI', 'version' => '1.0.1'],
             'servers' => [
                 [
@@ -80,7 +66,30 @@ final class OpenAPIProvider
                             'name' => 'limit',
                             'in' => 'query',
                             'required' => false,
-                            'schema' => ['type' => 'integer']
+                            'schema' => [
+                                'type' => ['integer', 'string'],
+                                'minimum' => 5,
+                                'exclusiveMinimum' => 6,
+                                'maximum' => 8.3,
+                                'exclusiveMaximum' => 8.21,
+                                'maxLength' => 2,
+                                'minLength' => 1,
+                                'pattern' => '.*',
+                                'maxItems' => 5,
+                                'minItems' => 3,
+                                'uniqueItems' => true,
+                                'maxContains' => 5,
+                                'minContains' => 2,
+                                'maxProperties' => 6,
+                                'minProperties' => 2,
+                                'required' => ['property1', 'property2'],
+                                'dependentRequired' => ['property2' => ['property3']],
+                                'not' => ['type' => 'integer'],
+                                // @todo cebe library does not convert these into schemas
+                                // 'if' => ['type' => 'integer'],
+                                // 'then' => ['type' => 'integer'],
+                                // 'else' => ['type' => 'integer'],
+                            ]
                         ]
                     ],
                     'get' => [
@@ -172,29 +181,20 @@ final class OpenAPIProvider
     }
 
     /**
-     * This will return a "detailed" cebe library, OpenAPI object
-     * Functions prefixed with "detailedV30" return equivalent OpenAPI
+     * This will return a "detailed" Membrane\OpenAPIReader\ValueObject\Valid\V31\OpenAPI object
+     * Functions prefixed with "detailedV31" return equivalent OpenAPI
      */
-    public static function detailedV30CebeObject(): Cebe\OpenApi
+    public static function detailedV31MembraneObject(): OpenAPI
     {
-        return new Cebe\OpenApi(json_decode(self::detailedV30String(), true));
-    }
-
-    /**
-     * This will return a "detailed" Membrane\OpenAPIReader\ValueObject\Valid\V30\OpenAPI object
-     * Functions prefixed with "detailedV30" return equivalent OpenAPI
-     */
-    public static function detailedV30MembraneObject(): OpenAPI
-    {
-        return OpenAPI::fromPartial(PartialHelper::createOpenAPI(
-            openapi: '3.0.0',
+        return OpenAPI::fromPartial(V31PartialHelper::createOpenAPI(
+            openapi: '3.1.0',
             title: 'My Detailed OpenAPI',
             version: '1.0.1',
             servers: [
-                PartialHelper::createServer(
+                V31PartialHelper::createServer(
                     url: 'https://server.net/{version}',
                     variables: [
-                        PartialHelper::createServerVariable(
+                        V31PartialHelper::createServerVariable(
                             name: 'version',
                             default: '2.1',
                             enum: ['2.0', '2.1', '2.2'],
@@ -203,35 +203,55 @@ final class OpenAPIProvider
                 ),
             ],
             paths: [
-                PartialHelper::createPathItem(
+                V31PartialHelper::createPathItem(
                     path: '/first',
                     parameters: [
-                        PartialHelper::createParameter(
+                        V31PartialHelper::createParameter(
                             name: 'limit',
                             in: 'query',
                             required: false,
-                            schema: PartialHelper::createSchema(
-                                type: 'integer'
+                            schema: V31PartialHelper::createSchema(
+                                type: ['integer', 'string'],
+                                minimum: 5,
+                                exclusiveMinimum: 6,
+                                maximum: 8.3,
+                                exclusiveMaximum: 8.21,
+                                maxLength: 2,
+                                minLength: 1,
+                                pattern: '.*',
+                                maxItems: 5,
+                                minItems: 3,
+                                uniqueItems: true,
+                                maxContains: 5,
+                                minContains: 2,
+                                maxProperties: 6,
+                                minProperties: 2,
+                                required:['property1', 'property2'],
+                                dependentRequired: ['property2' => ['property3']],
+                                not: V31PartialHelper::createSchema(type: 'integer'),
+                                // if: V31PartialHelper::createSchema(type: 'integer'),
+                                // then: V31PartialHelper::createSchema(type: 'integer'),
+                                // else: V31PartialHelper::createSchema(type: 'integer'),
                             )
                         ),
                     ],
-                    get: PartialHelper::createOperation(
+                    get: V31PartialHelper::createOperation(
                         operationId: 'first-get',
                         parameters: [
-                            PartialHelper::createParameter(
+                            V31PartialHelper::createParameter(
                                 name: 'pet',
                                 in: 'header',
                                 required: true,
                                 schema: null,
                                 content: [
-                                    PartialHelper::createMediaType(
+                                    V31PartialHelper::createMediaType(
                                         mediaType: 'application/json',
-                                        schema: PartialHelper::createSchema(
+                                        schema: V31PartialHelper::createSchema(
                                             allOf: [
-                                                PartialHelper::createSchema(
+                                                V31PartialHelper::createSchema(
                                                     type: 'integer'
                                                 ),
-                                                PartialHelper::createSchema(
+                                                V31PartialHelper::createSchema(
                                                     type: 'number'
                                                 )
                                             ]
@@ -242,40 +262,40 @@ final class OpenAPIProvider
                         ]
                     )
                 ),
-                PartialHelper::createPathItem(
+                V31PartialHelper::createPathItem(
                     path: '/second',
                     servers: [
-                        PartialHelper::createServer(
+                        V31PartialHelper::createServer(
                             url: 'https://second-server.co.uk'
                         ),
                     ],
                     parameters: [
-                        PartialHelper::createParameter(
+                        V31PartialHelper::createParameter(
                             name: 'limit',
                             in: 'query',
                             required: false,
-                            schema: PartialHelper::createSchema(
+                            schema: V31PartialHelper::createSchema(
                                 type: 'integer'
                             )
                         ),
                     ],
-                    get: PartialHelper::createOperation(
+                    get: V31PartialHelper::createOperation(
                         operationId: 'second-get',
                         parameters: [
-                            PartialHelper::createParameter(
+                            V31PartialHelper::createParameter(
                                 name: 'pet',
                                 in: 'header',
                                 required: true,
                                 schema: null,
                                 content: [
-                                    PartialHelper::createMediaType(
+                                    V31PartialHelper::createMediaType(
                                         mediaType: 'application/json',
-                                        schema: PartialHelper::createSchema(
+                                        schema: V31PartialHelper::createSchema(
                                             allOf: [
-                                                PartialHelper::createSchema(
+                                                V31PartialHelper::createSchema(
                                                     type: 'integer'
                                                 ),
-                                                PartialHelper::createSchema(
+                                                V31PartialHelper::createSchema(
                                                     type: 'number'
                                                 )
                                             ]
@@ -285,17 +305,17 @@ final class OpenAPIProvider
                             )
                         ]
                     ),
-                    put: PartialHelper::createOperation(
+                    put: V31PartialHelper::createOperation(
                         operationId: 'second-put',
                         servers: [
-                            PartialHelper::createServer(url: 'https://second-put.com')
+                            V31PartialHelper::createServer(url: 'https://second-put.com')
                         ],
                         parameters: [
-                            PartialHelper::createParameter(
+                            V31PartialHelper::createParameter(
                                 name: 'user',
                                 in: 'cookie',
                                 required: false,
-                                schema: PartialHelper::createSchema(
+                                schema: V31PartialHelper::createSchema(
                                     type: 'object'
                                 )
                             )

--- a/tests/fixtures/Helper/V31PartialHelper.php
+++ b/tests/fixtures/Helper/V31PartialHelper.php
@@ -169,6 +169,8 @@ final class V31PartialHelper
         Schema|null $items = null,
         Schema|null $contains = null,
         string|null $format = null,
+        string|null $title = null,
+        string|null $description = null,
     ): Schema {
         return new Schema(
             type: $type,
@@ -203,6 +205,8 @@ final class V31PartialHelper
             items: $items,
             contains: $contains,
             format: $format,
+            title: $title,
+            description: $description,
         );
     }
 }

--- a/tests/fixtures/Helper/V31PartialHelper.php
+++ b/tests/fixtures/Helper/V31PartialHelper.php
@@ -12,6 +12,7 @@ use Membrane\OpenAPIReader\ValueObject\Partial\PathItem;
 use Membrane\OpenAPIReader\ValueObject\Partial\Schema;
 use Membrane\OpenAPIReader\ValueObject\Partial\Server;
 use Membrane\OpenAPIReader\ValueObject\Partial\ServerVariable;
+use Membrane\OpenAPIReader\ValueObject\Value;
 
 final class V31PartialHelper
 {
@@ -125,31 +126,81 @@ final class V31PartialHelper
     }
 
     /**
-     * @param null|array<string>|string
+     * @param null|array<string>|string $type
+     * @param Value[]|null $enum
      * @param null|Schema[] $allOf
      * @param null|Schema[] $anyOf
      * @param null|Schema[] $oneOf
+     * @param string[] $required
+     * @param string[][] $dependentRequired
+     * @param Schema[] $dependentSchemas
      * @return Schema
      */
     public static function createSchema(
         null|array|string $type = null,
-        ?array $allOf = null,
-        ?array $anyOf = null,
-        ?array $oneOf = null,
+        array|null $enum = null,
+        Value|null $const = null,
+        float|int|null $multipleOf = null,
         float|int|null $exclusiveMaximum = null,
         float|int|null $exclusiveMinimum = null,
         float|int|null $maximum = null,
         float|int|null $minimum = null,
+        int|null $maxLength = null,
+        int $minLength = 0,
+        string|null $pattern = null,
+        int|null $maxItems = null,
+        int $minItems = 0,
+        bool $uniqueItems = false,
+        int|null $maxContains = null,
+        int $minContains = 1,
+        int|null $maxProperties = null,
+        int $minProperties = 0,
+        array $required = [],
+        array $dependentRequired = [],
+        ?array $allOf = null,
+        ?array $anyOf = null,
+        ?array $oneOf = null,
+        Schema|null $not = null,
+        Schema|null $if = null,
+        Schema|null $then = null,
+        Schema|null $else = null,
+        array $dependentSchemas = [],
+        array $prefixItems = [],
+        Schema|null $items = null,
+        Schema|null $contains = null,
     ): Schema {
         return new Schema(
             type: $type,
+            enum: $enum,
+            const: $const,
+            multipleOf: $multipleOf,
             exclusiveMaximum: $exclusiveMaximum,
             exclusiveMinimum: $exclusiveMinimum,
             maximum: $maximum,
             minimum: $minimum,
+            maxLength: $maxLength,
+            minLength: $minLength,
+            pattern: $pattern,
+            maxItems: $maxItems,
+            minItems: $minItems,
+            uniqueItems: $uniqueItems,
+            maxContains: $maxContains,
+            minContains: $minContains,
+            maxProperties: $maxProperties,
+            minProperties: $minProperties,
+            required: $required,
+            dependentRequired: $dependentRequired,
             allOf: $allOf,
             anyOf: $anyOf,
             oneOf: $oneOf,
+            not: $not,
+            if: $if,
+            then: $then,
+            else: $else,
+            dependentSchemas: $dependentSchemas,
+            prefixItems: $prefixItems,
+            items: $items,
+            contains: $contains,
         );
     }
 }

--- a/tests/fixtures/Helper/V31PartialHelper.php
+++ b/tests/fixtures/Helper/V31PartialHelper.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\Tests\Fixtures\Helper;
+
+use Membrane\OpenAPIReader\ValueObject\Partial\MediaType;
+use Membrane\OpenAPIReader\ValueObject\Partial\OpenAPI;
+use Membrane\OpenAPIReader\ValueObject\Partial\Operation;
+use Membrane\OpenAPIReader\ValueObject\Partial\Parameter;
+use Membrane\OpenAPIReader\ValueObject\Partial\PathItem;
+use Membrane\OpenAPIReader\ValueObject\Partial\Schema;
+use Membrane\OpenAPIReader\ValueObject\Partial\Server;
+use Membrane\OpenAPIReader\ValueObject\Partial\ServerVariable;
+
+final class V31PartialHelper
+{
+    public static function createOpenAPI(
+        ?string $openapi = '3.0.0',
+        ?string $title = 'Test API',
+        ?string $version = '1.0.0',
+        array $servers = [],
+        ?array $paths = [],
+    ): OpenAPI {
+        return new OpenAPI(
+            $openapi,
+            $title,
+            $version,
+            $servers,
+            $paths,
+        );
+    }
+
+    public static function createServer(
+        ?string $url = 'https://www.server.net',
+        ?array $variables = [],
+    ): Server{
+        return new Server(
+            $url,
+            $variables,
+        );
+    }
+
+    public static function createServerVariable(
+        ?string $name = 'default-name',
+        ?string $default = 'default-value',
+        ?array $enum = null,
+    ): ServerVariable {
+        return new ServerVariable(
+            $name,
+            $default,
+            $enum
+        );
+    }
+
+    public static function createPathItem(
+        ?string $path = '/path',
+        array $servers = [],
+        array $parameters = [],
+         ?Operation $get = null,
+         ?Operation $put = null,
+         ?Operation $post = null,
+         ?Operation $delete = null,
+         ?Operation $options = null,
+         ?Operation $head = null,
+         ?Operation $patch = null,
+         ?Operation $trace = null,
+    ): PathItem {
+        return new PathItem(
+            $path,
+            $servers,
+            $parameters,
+            $get,
+            $put,
+            $post,
+            $delete,
+            $options,
+            $head,
+            $patch,
+            $trace,
+        );
+    }
+
+    /** @param MediaType[] $content*/
+    public static function createParameter(
+        ?string $name = 'test-param',
+        ?string $in = 'path',
+        ?bool $required = true,
+        ?string $style = null,
+        ?bool $explode = null,
+        ?Schema $schema = new Schema(),
+        array $content = [],
+    ): Parameter {
+        return new Parameter(
+            $name,
+            $in,
+            $required,
+            $style,
+            $explode,
+            $schema,
+            $content
+        );
+    }
+
+    public static function createOperation(
+        ?string $operationId = 'test-id',
+        array $servers = [],
+        array $parameters = []
+    ): Operation {
+        return new Operation(
+            $operationId,
+            $servers,
+            $parameters
+        );
+    }
+
+    public static function createMediaType(
+        ?string $mediaType = 'application/json',
+        ?Schema $schema = null,
+    ): MediaType {
+        return new MediaType(
+            $mediaType,
+            $schema
+        );
+    }
+
+    /**
+     * @param null|array<string>|string
+     * @param null|Schema[] $allOf
+     * @param null|Schema[] $anyOf
+     * @param null|Schema[] $oneOf
+     * @return Schema
+     */
+    public static function createSchema(
+        null|array|string $type = null,
+        ?array $allOf = null,
+        ?array $anyOf = null,
+        ?array $oneOf = null,
+        float|int|null $exclusiveMaximum = null,
+        float|int|null $exclusiveMinimum = null,
+        float|int|null $maximum = null,
+        float|int|null $minimum = null,
+    ): Schema {
+        return new Schema(
+            type: $type,
+            exclusiveMaximum: $exclusiveMaximum,
+            exclusiveMinimum: $exclusiveMinimum,
+            maximum: $maximum,
+            minimum: $minimum,
+            allOf: $allOf,
+            anyOf: $anyOf,
+            oneOf: $oneOf,
+        );
+    }
+}

--- a/tests/fixtures/Helper/V31PartialHelper.php
+++ b/tests/fixtures/Helper/V31PartialHelper.php
@@ -168,6 +168,7 @@ final class V31PartialHelper
         array $prefixItems = [],
         Schema|null $items = null,
         Schema|null $contains = null,
+        string|null $format = null,
     ): Schema {
         return new Schema(
             type: $type,
@@ -201,6 +202,7 @@ final class V31PartialHelper
             prefixItems: $prefixItems,
             items: $items,
             contains: $contains,
+            format: $format,
         );
     }
 }

--- a/tests/fixtures/ProvidesTrainTravelApi.php
+++ b/tests/fixtures/ProvidesTrainTravelApi.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIReader\Tests\Fixtures;
+
+use Generator;
+use Membrane\OpenAPIReader\ValueObject\Partial;
+use Membrane\OpenAPIReader\ValueObject\Valid\Enum\Method;
+use Membrane\OpenAPIReader\ValueObject\Valid\Identifier;
+use Membrane\OpenAPIReader\ValueObject\Valid\V31;
+use Membrane\OpenAPIReader\ValueObject\Value;
+
+final class ProvidesTrainTravelApi
+{
+    private const API = __DIR__ . '/train-travel-api.yaml';
+
+    /**
+     * @return \Generator<array{
+     *     0: string,
+     *     1: string,
+     *     2: Method,
+     *     3: V31\Operation,
+     * }>
+     */
+    public static function provideOperations(): Generator
+    {
+        yield 'get-stations' => [
+            self::API,
+            '/stations',
+            Method::GET,
+            self::getStations(),
+        ];
+
+        yield 'get-trips' => [
+            self::API,
+            '/trips',
+            Method::GET,
+            self::getTrips(),
+        ];
+
+        yield 'get-bookings' => [
+            self::API,
+            '/bookings',
+            Method::GET,
+            self::getBookings(),
+        ];
+
+        yield 'create-booking' => [
+            self::API,
+            '/bookings',
+            Method::POST,
+            self::createBooking(),
+        ];
+
+        yield 'get-booking' => [
+            self::API,
+            '/bookings/{bookingId}',
+            Method::GET,
+            self::getBooking(),
+        ];
+
+        yield 'delete-booking' => [
+            self::API,
+            '/bookings/{bookingId}',
+            Method::DELETE,
+            self::deleteBooking(),
+        ];
+
+        yield 'create-booking-payment' => [
+            self::API,
+            '/bookings/{bookingId}/payment',
+            Method::POST,
+            self::createBookingPayment(),
+        ];
+    }
+
+    private static function getStations(): V31\Operation
+    {
+        return V31\Operation::fromPartial(
+            parentIdentifier: new Identifier('Train Travel API(1.0.0)', '/stations'),
+            pathServers: [new V31\Server(
+                new Identifier('Train Travel API(1.0.0)'),
+                new Partial\Server(url: 'https://api.example.com'),
+            )],
+            pathParameters: [],
+            method: Method::GET,
+            operation: new Partial\Operation('get-stations', [], [
+                new Partial\Parameter(
+                    name: 'page',
+                    in: 'query',
+                    schema: new Partial\Schema(type: 'integer', minimum: 1),
+                ),
+                new Partial\Parameter(
+                    name: 'coordinates',
+                    in: 'query',
+                    schema: new Partial\Schema(type: 'string'),
+                ),
+                new Partial\Parameter(
+                    name: 'search',
+                    in: 'query',
+                    schema: new Partial\Schema(type: 'string'),
+                ),
+            ])
+        );
+    }
+
+    private static function getTrips(): V31\Operation
+    {
+        return V31\Operation::fromPartial(
+            parentIdentifier: new Identifier('Train Travel API(1.0.0)', '/trips'),
+            pathServers: [new V31\Server(
+                new Identifier('Train Travel API(1.0.0)'),
+                new Partial\Server(url: 'https://api.example.com'),
+            )],
+            pathParameters: [],
+            method: Method::GET,
+            operation: new Partial\Operation('get-trips', [], [
+                new Partial\Parameter(
+                    name: 'origin',
+                    in: 'query',
+                    required: true,
+                    schema: new Partial\Schema(type: 'string'),
+                ),
+                new Partial\Parameter(
+                    name: 'destination',
+                    in: 'query',
+                    required: true,
+                    schema: new Partial\Schema(type: 'string'),
+                ),
+                new Partial\Parameter(
+                    name: 'date',
+                    in: 'query',
+                    required: true,
+                    schema: new Partial\Schema(type: 'string'),
+                ),
+                new Partial\Parameter(
+                    name: 'bicycles',
+                    in: 'query',
+                    schema: new Partial\Schema(type: 'boolean'),
+                ),
+                new Partial\Parameter(
+                    name: 'dogs',
+                    in: 'query',
+                    schema: new Partial\Schema(type: 'boolean'),
+                ),
+                new Partial\Parameter(
+                    name: 'page',
+                    in: 'query',
+                    schema: new Partial\Schema(type: 'number', default: new Value(1)),
+                ),
+            ])
+        );
+    }
+
+    private static function getBookings(): V31\Operation
+    {
+        return V31\Operation::fromPartial(
+            parentIdentifier: new Identifier('Train Travel API(1.0.0)', '/bookings'),
+            pathServers: [new V31\Server(
+                new Identifier('Train Travel API(1.0.0)'),
+                new Partial\Server(url: 'https://api.example.com'),
+            )],
+            pathParameters: [],
+            method: Method::GET,
+            operation: new Partial\Operation('get-bookings', [], [
+                new Partial\Parameter(
+                    name: 'page',
+                    in: 'query',
+                    schema: new Partial\Schema(
+                        type: 'integer',
+                        minimum: 1,
+                        default: new Value(1),
+                    ),
+                ),
+            ])
+        );
+    }
+
+    private static function createBooking(): V31\Operation
+    {
+        return V31\Operation::fromPartial(
+            parentIdentifier: new Identifier('Train Travel API(1.0.0)', '/bookings'),
+            pathServers: [new V31\Server(
+                new Identifier('Train Travel API(1.0.0)'),
+                new Partial\Server(url: 'https://api.example.com'),
+            )],
+            pathParameters: [],
+            method: Method::POST,
+            operation: new Partial\Operation('create-booking', [], [])
+        );
+    }
+
+    private static function getBooking(): V31\Operation
+    {
+        return V31\Operation::fromPartial(
+            parentIdentifier: new Identifier('Train Travel API(1.0.0)', '/bookings/{bookingId}'),
+            pathServers: [new V31\Server(
+                new Identifier('Train Travel API(1.0.0)'),
+                new Partial\Server(url: 'https://api.example.com'),
+            )],
+            pathParameters: [new V31\Parameter(
+                parentIdentifier: new Identifier('Train Travel API(1.0.0)', '/bookings/{bookingId}'),
+                parameter:new Partial\Parameter(
+                    name: 'bookingId',
+                    in: 'path',
+                    required: true,
+                    schema: new Partial\Schema(type: 'string'),
+                )
+            )],
+            method: Method::GET,
+            operation: new Partial\Operation('get-booking', [], [])
+        );
+    }
+
+    private static function deleteBooking(): V31\Operation
+    {
+        return V31\Operation::fromPartial(
+            parentIdentifier: new Identifier('Train Travel API(1.0.0)', '/bookings/{bookingId}'),
+            pathServers: [new V31\Server(
+                new Identifier('Train Travel API(1.0.0)'),
+                new Partial\Server(url: 'https://api.example.com'),
+            )],
+            pathParameters: [new V31\Parameter(
+                parentIdentifier: new Identifier('Train Travel API(1.0.0)', '/bookings/{bookingId}'),
+                parameter:new Partial\Parameter(
+                    name: 'bookingId',
+                    in: 'path',
+                    required: true,
+                    schema: new Partial\Schema(type: 'string'),
+                )
+            )],
+            method: Method::DELETE,
+            operation: new Partial\Operation('delete-booking', [], [])
+        );
+    }
+
+    private static function createBookingPayment(): V31\Operation
+    {
+        return V31\Operation::fromPartial(
+            parentIdentifier: new Identifier(
+                'Train Travel API(1.0.0)',
+                '/bookings/{bookingId}/payment'
+            ),
+            pathServers: [new V31\Server(
+                new Identifier('Train Travel API(1.0.0)'),
+                new Partial\Server(url: 'https://api.example.com'),
+            )],
+            pathParameters: [new V31\Parameter(
+                parentIdentifier: new Identifier(
+                    'Train Travel API(1.0.0)',
+                    '/bookings/{bookingId}/payment'
+                ),
+                parameter:new Partial\Parameter(
+                    name: 'bookingId',
+                    in: 'path',
+                    required: true,
+                    schema: new Partial\Schema(type: 'string'),
+                )
+            )],
+            method: Method::POST,
+            operation: new Partial\Operation('create-booking-payment', [], [])
+        );
+    }
+}

--- a/tests/fixtures/ProvidesTrainTravelApi.php
+++ b/tests/fixtures/ProvidesTrainTravelApi.php
@@ -120,19 +120,19 @@ final class ProvidesTrainTravelApi
                     name: 'origin',
                     in: 'query',
                     required: true,
-                    schema: new Partial\Schema(type: 'string'),
+                    schema: new Partial\Schema(type: 'string', format: 'uuid'),
                 ),
                 new Partial\Parameter(
                     name: 'destination',
                     in: 'query',
                     required: true,
-                    schema: new Partial\Schema(type: 'string'),
+                    schema: new Partial\Schema(type: 'string', format: 'uuid'),
                 ),
                 new Partial\Parameter(
                     name: 'date',
                     in: 'query',
                     required: true,
-                    schema: new Partial\Schema(type: 'string'),
+                    schema: new Partial\Schema(type: 'string', format: 'date-time'),
                 ),
                 new Partial\Parameter(
                     name: 'bicycles',
@@ -205,7 +205,7 @@ final class ProvidesTrainTravelApi
                     name: 'bookingId',
                     in: 'path',
                     required: true,
-                    schema: new Partial\Schema(type: 'string'),
+                    schema: new Partial\Schema(type: 'string', format: 'uuid'),
                 )
             )],
             method: Method::GET,
@@ -227,7 +227,7 @@ final class ProvidesTrainTravelApi
                     name: 'bookingId',
                     in: 'path',
                     required: true,
-                    schema: new Partial\Schema(type: 'string'),
+                    schema: new Partial\Schema(type: 'string', format: 'uuid'),
                 )
             )],
             method: Method::DELETE,
@@ -255,7 +255,7 @@ final class ProvidesTrainTravelApi
                     name: 'bookingId',
                     in: 'path',
                     required: true,
-                    schema: new Partial\Schema(type: 'string'),
+                    schema: new Partial\Schema(type: 'string', format: 'uuid'),
                 )
             )],
             method: Method::POST,

--- a/tests/fixtures/train-travel-api.yaml
+++ b/tests/fixtures/train-travel-api.yaml
@@ -1,0 +1,1188 @@
+openapi: 3.1.0
+info:
+  title: Train Travel API
+  description: |
+    API for finding and booking train trips across Europe.
+
+    ## Run in Postman
+    
+    Experiment with this API in Postman, using our Postman Collection.
+
+    [<img src="https://run.pstmn.io/button.svg" alt="Run In Postman" style="width: 128px; height: 32px;">](https://app.getpostman.com/run-collection/9265903-7a75a0d0-b108-4436-ba54-c6139698dc08?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9265903-7a75a0d0-b108-4436-ba54-c6139698dc08%26entityType%3Dcollection%26workspaceId%3Df507f69d-9564-419c-89a2-cb8e4c8c7b8f)
+  version: 1.0.0
+  contact:
+    name: Train Support
+    url: https://example.com/support
+    email: support@example.com
+  license:
+    name: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+    identifier: CC-BY-NC-SA-4.0
+  x-feedbackLink:
+    label: Submit Feedback
+    url: https://github.com/bump-sh-examples/train-travel-api/issues/new
+
+servers:
+  - url: https://api.example.com
+    description: Production
+
+security:
+  - OAuth2:
+      - read
+
+x-topics:
+  - title: Getting started
+    content:
+      $ref: ./docs/getting-started.md
+
+tags:
+  - name: Stations
+    description: |
+      Find and filter train stations across Europe, including their location
+      and local timezone.
+  - name: Trips
+    description: |
+      Timetables and routes for train trips between stations, including pricing
+      and availability.
+  - name: Bookings
+    description: |
+      Create and manage bookings for train trips, including passenger details
+      and optional extras.
+  - name: Payments
+    description: |
+      Pay for bookings using a card or bank account, and view payment
+      status and history.
+
+      > warn
+      > Bookings usually expire within 1 hour so you'll need to make your payment
+      > before the expiry date 
+
+paths:
+  /stations:
+    get:
+      summary: Get a list of train stations
+      description: Returns a paginated and searchable list of all train stations.
+      operationId: get-stations
+      tags:
+        - Stations
+      parameters:
+        - name: page
+          in: query
+          description: The page number to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          example: 1
+        - name: coordinates
+          in: query
+          description: >
+            The latitude and longitude of the user's location, to narrow down
+            the search results to sites within a proximity of this location.
+          required: false
+          schema:
+            type: string
+          example: 52.5200,13.4050
+        - name: search
+          in: query
+          description: >
+            A search term to filter the list of stations by name or address.
+          required: false
+          schema:
+            type: string
+            examples:
+              - Milano Centrale
+              - Paris
+      responses:
+        '200':
+          description: OK
+          headers:
+            Cache-Control:
+              $ref: '#/components/headers/Cache-Control'
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Station'
+              example:
+                data:
+                  - id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                    name: Berlin Hauptbahnhof
+                    address: Invalidenstraße 10557 Berlin, Germany
+                    country_code: DE
+                    timezone: Europe/Berlin
+                  - id: b2e783e1-c824-4d63-b37a-d8d698862f1d
+                    name: Paris Gare du Nord
+                    address: 18 Rue de Dunkerque 75010 Paris, France
+                    country_code: FR
+                    timezone: Europe/Paris
+                links:
+                  self: https://api.example.com/stations&page=2
+                  next: https://api.example.com/stations?page=3
+                  prev: https://api.example.com/stations?page=1
+            application/xml:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Wrapper-Collection'
+                  - properties:
+                      data:
+                        type: array
+                        xml:
+                          name: stations
+                          wrapped: true
+                        items:
+                          $ref: '#/components/schemas/Station'
+                  - properties:
+                      links:
+                        allOf:
+                          - $ref: '#/components/schemas/Links-Self'
+                          - $ref: '#/components/schemas/Links-Pagination'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /trips:
+    get:
+      summary: Get available train trips
+      description: >
+        Returns a list of available train trips between the specified origin and
+        destination stations on the given date, and allows for filtering by
+        bicycle and dog allowances.
+      operationId: get-trips
+      tags:
+        - Trips
+      parameters:
+        - name: origin
+          in: query
+          description: The ID of the origin station
+          required: true
+          schema:
+            type: string
+            format: uuid
+          example: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+        - name: destination
+          in: query
+          description: The ID of the destination station
+          required: true
+          schema:
+            type: string
+            format: uuid
+          example: b2e783e1-c824-4d63-b37a-d8d698862f1d
+        - name: date
+          in: query
+          description: The date and time of the trip in ISO 8601 format in origin station's timezone.
+          required: true
+          schema:
+            type: string
+            format: date-time
+          example: '2024-02-01T09:00:00Z'
+        - name: bicycles
+          in: query
+          description: Only return trips where bicycles are known to be allowed
+          required: false
+          schema:
+            type: boolean
+            default: false
+        - name: dogs
+          in: query
+          description: Only return trips where dogs are known to be allowed
+          required: false
+          schema:
+            type: boolean
+            default: false
+        - name: page
+          in: query
+          description: The page of results to be returned
+          required: false
+          schema:
+            type: number
+            default: 1
+      responses:
+        '200':
+          description: A list of available train trips
+          headers:
+            Cache-Control:
+              $ref: '#/components/headers/Cache-Control'
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Wrapper-Collection'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Trip'
+                  - properties:
+                      links:
+                        allOf:
+                          - $ref: '#/components/schemas/Links-Self'
+                          - $ref: '#/components/schemas/Links-Pagination'
+              example:
+                data:
+                  - id: ea399ba1-6d95-433f-92d1-83f67b775594
+                    origin: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                    destination: b2e783e1-c824-4d63-b37a-d8d698862f1d
+                    departure_time: '2024-02-01T10:00:00Z'
+                    arrival_time: '2024-02-01T16:00:00Z'
+                    price: 50
+                    operator: Deutsche Bahn
+                    bicycles_allowed: true
+                    dogs_allowed: true
+                  - id: 4d67459c-af07-40bb-bb12-178dbb88e09f
+                    origin: b2e783e1-c824-4d63-b37a-d8d698862f1d
+                    destination: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                    departure_time: '2024-02-01T12:00:00Z'
+                    arrival_time: '2024-02-01T18:00:00Z'
+                    price: 50
+                    operator: SNCF
+                    bicycles_allowed: true
+                    dogs_allowed: true
+                links:
+                  self: https://api.example.com/trips?origin=efdbb9d1-02c2-4bc3-afb7-6788d8782b1e&destination=b2e783e1-c824-4d63-b37a-d8d698862f1d&date=2024-02-01
+                  next: https://api.example.com/trips?origin=efdbb9d1-02c2-4bc3-afb7-6788d8782b1e&destination=b2e783e1-c824-4d63-b37a-d8d698862f1d&date=2024-02-01&page=2
+            application/xml:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Wrapper-Collection'
+                  - properties:
+                      data:
+                        type: array
+                        xml:
+                          name: trips
+                          wrapped: true
+                        items:
+                          $ref: '#/components/schemas/Trip'
+                  - properties:
+                      links:
+                        allOf:
+                          - $ref: '#/components/schemas/Links-Self'
+                          - $ref: '#/components/schemas/Links-Pagination'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /bookings:
+    get:
+      operationId: get-bookings
+      summary: List existing bookings
+      description: Returns a list of all trip bookings by the authenticated user.
+      tags:
+        - Bookings
+      parameters:
+        - name: page
+          in: query
+          description: The page number to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          example: 1
+      responses:
+        '200':
+          description: A list of bookings
+          headers:
+            Cache-Control:
+              $ref: '#/components/headers/Cache-Control'
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Wrapper-Collection'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Booking'
+                  - properties:
+                      links:
+                        allOf:
+                          - $ref: '#/components/schemas/Links-Self'
+                          - $ref: '#/components/schemas/Links-Pagination'
+              example:
+                data:
+                  - id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                    trip_id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                    passenger_name: John Doe
+                    has_bicycle: true
+                    has_dog: true
+                  - id: b2e783e1-c824-4d63-b37a-d8d698862f1d
+                    trip_id: b2e783e1-c824-4d63-b37a-d8d698862f1d
+                    passenger_name: Jane Smith
+                    has_bicycle: false
+                    has_dog: false
+                links:
+                  self: https://api.example.com/bookings
+                  next: https://api.example.com/bookings?page=2
+            application/xml:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Wrapper-Collection'
+                  - properties:
+                      data:
+                        type: array
+                        xml:
+                          name: bookings
+                          wrapped: true
+                        items:
+                          $ref: '#/components/schemas/Booking'
+                  - properties:
+                      links:
+                        allOf:
+                          - $ref: '#/components/schemas/Links-Self'
+                          - $ref: '#/components/schemas/Links-Pagination'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      operationId: create-booking
+      summary: Create a booking
+      description: A booking is a temporary hold on a trip. It is not confirmed until the payment is processed.
+      tags:
+        - Bookings
+      security:
+        - OAuth2:
+            - write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Booking'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Booking'
+      responses:
+        '201':
+          description: Booking successful
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Booking'
+                  - properties:
+                      links:
+                        $ref: '#/components/schemas/Links-Self'
+
+              example:
+                id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                trip_id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                passenger_name: John Doe
+                has_bicycle: true
+                has_dog: true
+                links:
+                  self: https://api.example.com/bookings/efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+            application/xml:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Booking'
+                  - properties:
+                      links:
+                        $ref: '#/components/schemas/Links-Self'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /bookings/{bookingId}:
+    parameters:
+      - name: bookingId
+        in: path
+        required: true
+        description: The ID of the booking to retrieve.
+        schema:
+          type: string
+          format: uuid
+        example: 1725ff48-ab45-4bb5-9d02-88745177dedb
+    get:
+      summary: Get a booking
+      description: Returns the details of a specific booking.
+      operationId: get-booking
+      tags:
+        - Bookings
+      responses:
+        '200':
+          description: The booking details
+          headers:
+            Cache-Control:
+              $ref: '#/components/headers/Cache-Control'
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Booking'
+                  - properties:
+                      links:
+                        $ref: '#/components/schemas/Links-Self'
+              example:
+                id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                trip_id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                passenger_name: John Doe
+                has_bicycle: true
+                has_dog: true
+                links:
+                  self: https://api.example.com/bookings/1725ff48-ab45-4bb5-9d02-88745177dedb
+            application/xml:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Booking'
+                  - properties:
+                      links:
+                        $ref: '#/components/schemas/Links-Self'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      summary: Delete a booking
+      description: Deletes a booking, cancelling the hold on the trip.
+      operationId: delete-booking
+      security:
+        - OAuth2:
+            - write
+      tags:
+        - Bookings
+      responses:
+        '204':
+          description: Booking deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /bookings/{bookingId}/payment:
+    parameters:
+      - name: bookingId
+        in: path
+        required: true
+        description: The ID of the booking to pay for.
+        schema:
+          type: string
+          format: uuid
+        example: 1725ff48-ab45-4bb5-9d02-88745177dedb
+    post:
+      summary: Pay for a Booking
+      description: A payment is an attempt to pay for the booking, which will confirm the booking for the user and enable them to get their tickets.
+      operationId: create-booking-payment
+      tags:
+        - Payments
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingPayment'
+            examples:
+              Card:
+                summary: Card Payment
+                value:
+                  amount: 49.99
+                  currency: gbp
+                  source:
+                    object: card
+                    name: J. Doe
+                    number: '4242424242424242'
+                    cvc: 123
+                    exp_month: 12
+                    exp_year: 2025
+                    address_line1: 123 Fake Street
+                    address_line2: 4th Floor
+                    address_city: London
+                    address_country: gb
+                    address_post_code: N12 9XX
+              Bank:
+                summary: Bank Account Payment
+                value:
+                  amount: 100.5
+                  currency: gbp
+                  source:
+                    object: bank_account
+                    name: J. Doe
+                    number: '00012345'
+                    sort_code: '000123'
+                    account_type: individual
+                    bank_name: Starling Bank
+                    country: gb
+      responses:
+        '200':
+          description: Payment successful
+          headers:
+            Cache-Control:
+              $ref: '#/components/headers/Cache-Control'
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BookingPayment'
+                  - properties:
+                      links:
+                        $ref: '#/components/schemas/Links-Booking'
+              examples:
+                Card:
+                  summary: Card Payment
+                  value:
+                    id: 2e3b4f5a-6b7c-8d9e-0f1a-2b3c4d5e6f7a
+                    amount: 49.99
+                    currency: gbp
+                    source:
+                      object: card
+                      name: J. Doe
+                      number: '************4242'
+                      cvc: 123
+                      exp_month: 12
+                      exp_year: 2025
+                      address_country: gb
+                      address_post_code: N12 9XX
+                    status: succeeded
+                    links:
+                      booking: https://api.example.com/bookings/1725ff48-ab45-4bb5-9d02-88745177dedb/payment
+                Bank:
+                  summary: Bank Account Payment
+                  value:
+                    id: 2e3b4f5a-6b7c-8d9e-0f1a-2b3c4d5e6f7a
+                    amount: 100.5
+                    currency: gbp
+                    source:
+                      object: bank_account
+                      name: J. Doe
+                      account_type: individual
+                      number: '*********2345'
+                      sort_code: '000123'
+                      bank_name: Starling Bank
+                      country: gb
+                    status: succeeded
+                    links:
+                      booking: https://api.example.com/bookings/1725ff48-ab45-4bb5-9d02-88745177dedb
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+webhooks:
+  newBooking:
+    post:
+      operationId: new-booking
+      summary: New Booking
+      description: |
+        Subscribe to new bookings being created, to update integrations for your users.  Related data is available via the links provided in the request.
+      tags:
+        - Bookings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/Booking'
+                - properties:
+                    links:
+                      allOf:
+                        - $ref: '#/components/schemas/Links-Self'
+                        - $ref: '#/components/schemas/Links-Pagination'
+            example:
+              id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+              trip_id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+              passenger_name: John Doe
+              has_bicycle: true
+              has_dog: true
+              links:
+                self: https://api.example.com/bookings/1725ff48-ab45-4bb5-9d02-88745177dedb
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully.
+
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      description: OAuth 2.0 authorization code following RFC8725 best practices.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            read: Read access
+            write: Write access
+  schemas:
+    Station:
+      type: object
+      xml:
+        name: station
+      required:
+        - id
+        - name
+        - address
+        - country_code
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the station.
+          examples:
+            - efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+            - b2e783e1-c824-4d63-b37a-d8d698862f1d
+        name:
+          type: string
+          description: The name of the station
+          examples:
+            - Berlin Hauptbahnhof
+            - Paris Gare du Nord
+        address:
+          type: string
+          description: The address of the station.
+          examples:
+            - Invalidenstraße 10557 Berlin, Germany
+            - 18 Rue de Dunkerque 75010 Paris, France
+        country_code:
+          type: string
+          description: The country code of the station.
+          format: iso-country-code
+          examples:
+            - DE
+            - FR
+        timezone:
+          type: string
+          description: The timezone of the station in the [IANA Time Zone Database format](https://www.iana.org/time-zones).
+          examples:
+            - Europe/Berlin
+            - Europe/Paris
+    Links-Self:
+      type: object
+      properties:
+        self:
+          type: string
+          format: uri
+    Links-Pagination:
+      type: object
+      properties:
+        next:
+          type: string
+          format: uri
+        prev:
+          type: string
+          format: uri
+    Problem:
+      type: object
+      xml:
+        name: problem
+        namespace: urn:ietf:rfc:7807
+      properties:
+        type:
+          type: string
+          description: A URI reference that identifies the problem type
+          example: https://example.com/probs/out-of-credit
+        title:
+          type: string
+          description: A short, human-readable summary of the problem type
+          example: You do not have enough credit.
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence of the problem
+          example: Your current balance is 30, but that costs 50.
+        instance:
+          type: string
+          description: A URI reference that identifies the specific occurrence of the problem
+          example: /account/12345/msgs/abc
+        status:
+          type: integer
+          description: The HTTP status code
+          example: 400
+    Trip:
+      type: object
+      xml:
+        name: trip
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the trip
+          examples:
+            - 4f4e4e1-c824-4d63-b37a-d8d698862f1d
+        origin:
+          type: string
+          description: The starting station of the trip
+          examples:
+            - Berlin Hauptbahnhof
+            - Paris Gare du Nord
+        destination:
+          type: string
+          description: The destination station of the trip
+          examples:
+            - Paris Gare du Nord
+            - Berlin Hauptbahnhof
+        departure_time:
+          type: string
+          format: date-time
+          description: The date and time when the trip departs
+          examples:
+            - '2024-02-01T10:00:00Z'
+        arrival_time:
+          type: string
+          format: date-time
+          description: The date and time when the trip arrives
+          examples:
+            - '2024-02-01T16:00:00Z'
+        operator:
+          type: string
+          description: The name of the operator of the trip
+          examples:
+            - Deutsche Bahn
+            - SNCF
+        price:
+          type: number
+          description: The cost of the trip
+          examples:
+            - 50
+        bicycles_allowed:
+          type: boolean
+          description: Indicates whether bicycles are allowed on the trip
+        dogs_allowed:
+          type: boolean
+          description: Indicates whether dogs are allowed on the trip
+    Booking:
+      type: object
+      xml:
+        name: booking
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the booking
+          readOnly: true
+          examples:
+            - 3f3e3e1-c824-4d63-b37a-d8d698862f1d
+        trip_id:
+          type: string
+          format: uuid
+          description: Identifier of the booked trip
+          examples:
+            - 4f4e4e1-c824-4d63-b37a-d8d698862f1d
+        passenger_name:
+          type: string
+          description: Name of the passenger
+          examples:
+            - John Doe
+        has_bicycle:
+          type: boolean
+          description: Indicates whether the passenger has a bicycle.
+        has_dog:
+          type: boolean
+          description: Indicates whether the passenger has a dog.
+    Wrapper-Collection:
+      description: This is a generic request/response wrapper which contains both data and links which serve as hypermedia controls (HATEOAS).
+      type: object
+      properties:
+        data:
+          description: The wrapper for a collection is an array of objects.
+          type: array
+          items:
+            type: object
+        links:
+          description: A set of hypermedia links which serve as controls for the client.
+          type: object
+          readOnly: true
+      xml:
+        name: data
+    BookingPayment:
+      type: object
+      properties:
+        id:
+          description: Unique identifier for the payment. This will be a unique identifier for the payment, and is used to reference the payment in other objects.
+          type: string
+          format: uuid
+          readOnly: true
+        amount:
+          description: Amount intended to be collected by this payment. A positive decimal figure describing the amount to be collected.
+          type: number
+          exclusiveMinimum: 0
+          examples:
+            - 49.99
+        currency:
+          description: Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
+          type: string
+          enum:
+            - bam
+            - bgn
+            - chf
+            - eur
+            - gbp
+            - nok
+            - sek
+            - try
+        source:
+          unevaluatedProperties: false
+          description: The payment source to take the payment from. This can be a card or a bank account. Some of these properties will be hidden on read to protect PII leaking.
+          oneOf:
+            - title: Card
+              description: A card (debit or credit) to take payment from.
+              type: object
+              properties:
+                object:
+                  type: string
+                  const: card
+                name:
+                  type: string
+                  description: Cardholder's full name as it appears on the card.
+                  examples:
+                    - Francis Bourgeois
+                number:
+                  type: string
+                  description: The card number, as a string without any separators. On read all but the last four digits will be masked for security.
+                  examples:
+                    - '4242424242424242'
+                cvc:
+                  type: integer
+                  description: Card security code, 3 or 4 digits usually found on the back of the card.
+                  minLength: 3
+                  maxLength: 4
+                  writeOnly: true
+
+                  example: 123
+                exp_month:
+                  type: integer
+                  format: int64
+                  description: Two-digit number representing the card's expiration month.
+                  examples:
+                    - 12
+                exp_year:
+                  type: integer
+                  format: int64
+                  description: Four-digit number representing the card's expiration year.
+                  examples:
+                    - 2025
+                address_line1:
+                  type: string
+                  writeOnly: true
+                address_line2:
+                  type: string
+                  writeOnly: true
+                address_city:
+                  type: string
+                address_country:
+                  type: string
+                address_post_code:
+                  type: string
+              required:
+                - name
+                - number
+                - cvc
+                - exp_month
+                - exp_year
+                - address_country
+            - title: Bank Account
+              description: A bank account to take payment from. Must be able to make payments in the currency specified in the payment.
+              type: object
+              properties:
+                object:
+                  const: bank_account
+                  type: string
+                name:
+                  type: string
+                number:
+                  type: string
+                  description: The account number for the bank account, in string form. Must be a current account.
+                sort_code:
+                  type: string
+                  description: The sort code for the bank account, in string form. Must be a six-digit number.
+                account_type:
+                  enum:
+                    - individual
+                    - company
+                  type: string
+                  description: The type of entity that holds the account. This can be either `individual` or `company`.
+                bank_name:
+                  type: string
+                  description: The name of the bank associated with the routing number.
+                  examples:
+                    - Starling Bank
+                country:
+                  type: string
+                  description: Two-letter country code (ISO 3166-1 alpha-2).
+              required:
+                - name
+                - number
+                - account_type
+                - bank_name
+                - country
+        status:
+          description: The status of the payment, one of `pending`, `succeeded`, or `failed`.
+          type: string
+          enum:
+            - pending
+            - succeeded
+            - failed
+          readOnly: true
+    Links-Booking:
+      type: object
+      properties:
+        booking:
+          type: string
+          format: uri
+          examples:
+            - https://api.example.com/bookings/1725ff48-ab45-4bb5-9d02-88745177dedb
+  headers:
+    Cache-Control:
+      description: |
+        The Cache-Control header communicates directives for caching mechanisms in both requests and responses. 
+        It is used to specify the caching directives in responses to prevent caches from storing sensitive information.
+      schema:
+        type: string
+        description: A comma-separated list of directives as defined in [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html).
+        examples:
+          - max-age=3600
+          - max-age=604800, public
+          - no-store
+          - no-cache
+          - private
+
+    RateLimit:
+      description: |
+        The RateLimit header communicates quota policies. It contains a `limit` to
+        convey the expiring limit, `remaining` to convey the remaining quota units,
+        and `reset` to convey the time window reset time.
+      schema:
+        type: string
+        examples:
+          - limit=10, remaining=0, reset=10
+
+    Retry-After:
+      description: |
+        The Retry-After header indicates how long the user agent should wait before making a follow-up request. 
+        The value is in seconds and can be an integer or a date in the future. 
+        If the value is an integer, it indicates the number of seconds to wait. 
+        If the value is a date, it indicates the time at which the user agent should make a follow-up request.
+      schema:
+        type: string
+      examples:
+        integer:
+          value: '120'
+          summary: Retry after 120 seconds
+        date:
+          value: 'Fri, 31 Dec 2021 23:59:59 GMT'
+          summary: Retry after the specified date
+
+  responses:
+    BadRequest:
+      description: Bad Request
+      headers:
+        RateLimit:
+          $ref: '#/components/headers/RateLimit'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/bad-request
+            title: Bad Request
+            status: 400
+            detail: The request is invalid or missing required parameters.
+        application/problem+xml:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/bad-request
+            title: Bad Request
+            status: 400
+            detail: The request is invalid or missing required parameters.
+
+    Conflict:
+      description: Conflict
+      headers:
+        RateLimit:
+          $ref: '#/components/headers/RateLimit'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/conflict
+            title: Conflict
+            status: 409
+            detail: There is a conflict with an existing resource.
+        application/problem+xml:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/conflict
+            title: Conflict
+            status: 409
+            detail: There is a conflict with an existing resource.
+
+    Forbidden:
+      description: Forbidden
+      headers:
+        RateLimit:
+          $ref: '#/components/headers/RateLimit'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/forbidden
+            title: Forbidden
+            status: 403
+            detail: Access is forbidden with the provided credentials.
+        application/problem+xml:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/forbidden
+            title: Forbidden
+            status: 403
+            detail: Access is forbidden with the provided credentials.
+
+    InternalServerError:
+      description: Internal Server Error
+      headers:
+        RateLimit:
+          $ref: '#/components/headers/RateLimit'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/internal-server-error
+            title: Internal Server Error
+            status: 500
+            detail: An unexpected error occurred.
+        application/problem+xml:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/internal-server-error
+            title: Internal Server Error
+            status: 500
+            detail: An unexpected error occurred.
+
+    NotFound:
+      description: Not Found
+      headers:
+        RateLimit:
+          $ref: '#/components/headers/RateLimit'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/not-found
+            title: Not Found
+            status: 404
+            detail: The requested resource was not found.
+        application/problem+xml:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/not-found
+            title: Not Found
+            status: 404
+            detail: The requested resource was not found.
+
+    TooManyRequests:
+      description: Too Many Requests
+      headers:
+        RateLimit:
+          $ref: '#/components/headers/RateLimit'
+        Retry-After:
+          $ref: '#/components/headers/Retry-After'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/too-many-requests
+            title: Too Many Requests
+            status: 429
+            detail: You have exceeded the rate limit.
+        application/problem+xml:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/too-many-requests
+            title: Too Many Requests
+            status: 429
+            detail: You have exceeded the rate limit.
+
+    Unauthorized:
+      description: Unauthorized
+      headers:
+        RateLimit:
+          $ref: '#/components/headers/RateLimit'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/unauthorized
+            title: Unauthorized
+            status: 401
+            detail: You do not have the necessary permissions.
+        application/problem+xml:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: https://example.com/errors/unauthorized
+            title: Unauthorized
+            status: 401
+            detail: You do not have the necessary permissions.


### PR DESCRIPTION
This adds support for OpenAPI 3.1, enough that it doesn't explode on _most_ keywords.

It has issues with _new keywords_ for subschemas.

This may be fixable in the fork.

Currently depending on a personal fork.