### PR TITLE
Test min max

### DIFF
--- a/src/Factory/V30/FromCebe.php
+++ b/src/Factory/V30/FromCebe.php
@@ -145,7 +145,9 @@ final class FromCebe
 
         return new Schema(
             type: $schema->type,
-            enum: $schema->enum ?? null,
+            enum: isset($schema->enum) ?
+                array_map(fn($e) => new Value($e), $schema->enum) :
+                null,
             default: isset($schema->default) ? new Value($schema->default) : null,
             nullable: $schema->nullable ?? false,
             multipleOf: $schema->multipleOf ?? null,

--- a/src/Factory/V30/FromCebe.php
+++ b/src/Factory/V30/FromCebe.php
@@ -185,6 +185,7 @@ final class FromCebe
                 $schema->additionalProperties :
                 self::createSchema($schema->additionalProperties) ?? true) :
                 true,
+            format: $schema->format ?? null,
         );
     }
 

--- a/src/Factory/V30/FromCebe.php
+++ b/src/Factory/V30/FromCebe.php
@@ -146,7 +146,6 @@ final class FromCebe
         return new Schema(
             type: $schema->type,
             enum: $schema->enum ?? null,
-            const: $schema->const ?? null,
             default: isset($schema->default) ? new Value($schema->default) : null,
             nullable: $schema->nullable ?? false,
             multipleOf: $schema->multipleOf ?? null,
@@ -160,22 +159,13 @@ final class FromCebe
             maxItems: $schema->maxItems ?? null,
             minItems: $schema->minItems ?? 0,
             uniqueItems: $schema->uniqueItems ?? false,
-            maxContains: $schema->maxContains ?? null,
-            minContains: $schema->minContains ?? null,
             maxProperties: $schema->maxProperties ?? null,
             minProperties: $schema->minProperties ?? 0,
             required: $schema->required ?? null,
-            dependentRequired: $schema->dependentRequired ?? null,
             allOf: isset($schema->allOf) ? $createSchemas($schema->allOf) : null,
             anyOf: isset($schema->anyOf) ? $createSchemas($schema->anyOf) : null,
             oneOf: isset($schema->oneOf) ? $createSchemas($schema->oneOf) : null,
             not: isset($schema->not) ? self::createSchema($schema->not) : null,
-            if: isset($schema->if) ? self::createSchema($schema->if) : null,
-            then: isset($schema->then) ? self::createSchema($schema->then) : null,
-            else: isset($schema->else) ? self::createSchema($schema->else) : null,
-            dependentSchemas: isset($schema->dependentSchemas) ?
-                $createSchemas($schema->dependentSchemas) :
-                null,
             items: isset($schema->items) ? self::createSchema($schema->items) : null,
             properties: isset($schema->properties) ? $createSchemas($schema->properties) : [],
             additionalProperties: isset($schema->additionalProperties) ? (is_bool($schema->additionalProperties) ?

--- a/src/Factory/V30/FromCebe.php
+++ b/src/Factory/V30/FromCebe.php
@@ -176,11 +176,8 @@ final class FromCebe
             dependentSchemas: isset($schema->dependentSchemas) ?
                 $createSchemas($schema->dependentSchemas) :
                 null,
-            items: isset($schema->items) ? (is_array($schema->items) ?
-                $createSchemas($schema->items) :
-                self::createSchema($schema->items)) :
-                null,
-            properties: isset($schema->properties) ? $createSchemas($schema->properties) : null,
+            items: isset($schema->items) ? self::createSchema($schema->items) : null,
+            properties: isset($schema->properties) ? $createSchemas($schema->properties) : [],
             additionalProperties: isset($schema->additionalProperties) ? (is_bool($schema->additionalProperties) ?
                 $schema->additionalProperties :
                 self::createSchema($schema->additionalProperties) ?? true) :

--- a/src/ValueObject/Partial/Schema.php
+++ b/src/ValueObject/Partial/Schema.php
@@ -120,6 +120,12 @@ final class Schema
          */
         public bool|Schema $unevaluatedItems = true,
         public bool|Schema $unevaluatedProperties = true,
+
+        /**
+         * Keywords that MAY provide additional validation, depending on tool
+         * https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-7
+         */
+        public string|null $format = null,
     ) {
     }
 }

--- a/src/ValueObject/Partial/Schema.php
+++ b/src/ValueObject/Partial/Schema.php
@@ -119,7 +119,6 @@ final class Schema
          */
         public bool|Schema $unevaluatedItems = true,
         public bool|Schema $unevaluatedProperties = true,
-
         /**
          * Keywords that MAY provide additional validation, depending on tool
          * https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-7

--- a/src/ValueObject/Partial/Schema.php
+++ b/src/ValueObject/Partial/Schema.php
@@ -98,17 +98,16 @@ final class Schema
          * 3.1 https://json-schema.org/draft/2020-12/json-schema-core#name-keywords-for-applying-subschema
          */
         /** @var array<Schema> */
-        public array|null $prefixItems = null,
-        /** @var array<Schema>|Schema|null */
-        public array|Schema|null $items = null,
+        public array $prefixItems = [],
+        public Schema|null $items = null,
         public Schema|null $contains = null,
         /**
          * Keywords for applying subschemas to arrays
          * 3.0 https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-5.22
          * 3.1 https://json-schema.org/draft/2020-12/json-schema-core#name-keywords-for-applying-subschemas
          */
-        /** @var array<string, Schema>|null */
-        public array|null $properties = [],
+        /** @var array<string, Schema> */
+        public array $properties = [],
         /** @var array<string, Schema> */
         public array $patternProperties = [],
         public bool|Schema $additionalProperties = true,

--- a/src/ValueObject/Valid/V30/Schema.php
+++ b/src/ValueObject/Valid/V30/Schema.php
@@ -300,14 +300,8 @@ final class Schema extends Validated implements Valid\Schema
         return $result;
     }
 
-    /**
-     * @param array<Partial\Schema>|Partial\Schema|null $items
-     * @return array<Schema>|Schema|null
-     */
-    private function validateItems(
-        Type|null $type,
-        array|Partial\Schema|null $items,
-    ): array|Schema|null {
+    private function validateItems(Type|null $type, Partial\Schema|null $items): Schema|null
+    {
         if (is_null($items)) {
             //@todo update tests to support this validation
             //if ($type == Type::Array) {

--- a/src/ValueObject/Valid/V30/Schema.php
+++ b/src/ValueObject/Valid/V30/Schema.php
@@ -55,6 +55,7 @@ final class Schema extends Validated implements Valid\Schema
     public readonly array|null $oneOf;
     public readonly Schema|null $not;
 
+    public readonly string|null $format;
 
     /** @var Type[] */
     private readonly array $typesItCanBe;
@@ -100,6 +101,8 @@ final class Schema extends Validated implements Valid\Schema
         $this->not = isset($schema->not) ?
             new Schema($this->getIdentifier()->append('not'), $schema->not) :
             null;
+
+        $this->format = $schema->format;
 
         $this->typesItCanBe = array_map(
             fn($t) => Type::from($t),

--- a/src/ValueObject/Valid/V30/Schema.php
+++ b/src/ValueObject/Valid/V30/Schema.php
@@ -33,8 +33,8 @@ final class Schema extends Validated implements Valid\Schema
     public readonly int $minLength;
     public readonly string|null $pattern;
 
-    /** @var array<Schema>|Schema|null  */
-    public readonly array|Schema|null $items;
+    /** @var Schema|null  */
+    public readonly Schema|null $items;
     public readonly int|null $maxItems;
     public readonly int $minItems;
     public readonly bool $uniqueItems;
@@ -315,10 +315,6 @@ final class Schema extends Validated implements Valid\Schema
             //}
 
             return $items;
-        }
-
-        if (is_array($items)) {
-            return $this->validateSubSchemas('items', $items);
         }
 
         return new Schema($this->getIdentifier()->append('items'), $items);

--- a/tests/fixtures/Helper/PartialHelper.php
+++ b/tests/fixtures/Helper/PartialHelper.php
@@ -12,6 +12,7 @@ use Membrane\OpenAPIReader\ValueObject\Partial\PathItem;
 use Membrane\OpenAPIReader\ValueObject\Partial\Schema;
 use Membrane\OpenAPIReader\ValueObject\Partial\Server;
 use Membrane\OpenAPIReader\ValueObject\Partial\ServerVariable;
+use Membrane\OpenAPIReader\ValueObject\Value;
 
 final class PartialHelper
 {
@@ -125,22 +126,67 @@ final class PartialHelper
     }
 
     /**
+     * @param null|Value[] $enum
      * @param null|Schema[] $allOf
      * @param null|Schema[] $anyOf
      * @param null|Schema[] $oneOf
+     * @param Schema[] $properties
+     * @param null|string[] $required
      * @return Schema
      */
     public static function createSchema(
-        ?string $type = null,
-        ?array $allOf = null,
-        ?array $anyOf = null,
-        ?array $oneOf = null,
+        string|null $type = null,
+        bool $nullable = false,
+        array|null $enum = null,
+        Value|null $default = null,
+        float|int|null $multipleOf = null,
+        float|int|null $maximum = null,
+        float|int|null $minimum = null,
+        bool $exclusiveMaximum = false,
+        bool $exclusiveMinimum = false,
+        int|null $maxLength = null,
+        int $minLength = 0,
+        string|null $pattern = null,
+        int|null $maxItems = null,
+        int $minItems = 0,
+        bool $uniqueItems = false,
+        int|null $maxProperties = null,
+        int $minProperties = 0,
+        array|null $required = null,
+        Schema|null $items = null,
+        array $properties = [],
+        array|null $allOf = null,
+        array|null $anyOf = null,
+        array|null $oneOf = null,
+        Schema|null $not = null,
+        string|null $format = null,
     ): Schema {
         return new Schema(
             type: $type,
+            enum: $enum,
+            default: $default,
+            nullable: $nullable,
+            multipleOf: $multipleOf,
+            exclusiveMaximum: $exclusiveMaximum,
+            exclusiveMinimum: $exclusiveMinimum,
+            maximum: $maximum,
+            minimum: $minimum,
+            maxLength: $maxLength,
+            minLength: $minLength,
+            pattern: $pattern,
+            maxItems: $maxItems,
+            minItems: $minItems,
+            uniqueItems: $uniqueItems,
+            maxProperties: $maxProperties,
+            minProperties: $minProperties,
+            required: $required,
             allOf: $allOf,
             anyOf: $anyOf,
             oneOf: $oneOf,
+            not: $not,
+            items: $items,
+            properties: $properties,
+            format: $format,
         );
     }
 }


### PR DESCRIPTION
## Simplifies `items`:

OpenAPI 3.0 explicitly states that `items` must not be an array.

OpenAPI 3.1 depends on a later version of the Json Schema which does not allow `items` to be an array.

## Adds `format`

Useful for Membrane core

## Tests getRelevantMinimum and getRelevantMaximum

This required updating the PartialHelper to allow constructing with all of the keywords for 3.0