### PR TITLE
Add getTypes

### DIFF
--- a/src/ValueObject/Valid/Schema.php
+++ b/src/ValueObject/Valid/Schema.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Membrane\OpenAPIReader\ValueObject\Valid;
 
 use Membrane\OpenAPIReader\ValueObject\Limit;
+use Membrane\OpenAPIReader\ValueObject\Valid\Enum\Type;
 
 interface Schema
 {
+    /** @return Type[] */
+    public function getTypes(): array;
     public function getRelevantMinimum(): ?Limit;
     public function getRelevantMaximum(): ?Limit;
 }

--- a/src/ValueObject/Valid/V30/Schema.php
+++ b/src/ValueObject/Valid/V30/Schema.php
@@ -138,6 +138,20 @@ final class Schema extends Validated implements Valid\Schema
         return false;
     }
 
+    /** @return Type[] */
+    public function getTypes(): array
+    {
+        $result = isset($this->type) ?
+            [$this->type] :
+            Type::casesForVersion(OpenAPIVersion::Version_3_0);
+
+        if ($this->nullable) {
+            $result[] = Type::Null;
+        }
+
+        return $result;
+    }
+
     public function getRelevantMaximum(): ?Limit
     {
         return isset($this->maximum) ?

--- a/tests/ValueObject/Valid/V30/SchemaTest.php
+++ b/tests/ValueObject/Valid/V30/SchemaTest.php
@@ -139,6 +139,19 @@ class SchemaTest extends TestCase
         self::assertEquals($expected, $sut->getRelevantMinimum());
     }
 
+    /**
+     * @param Type[] $expected
+     */
+    #[Test]
+    #[TestDox('It gets the types allowed, in a version agnostic format')]
+    #[DataProvider('provideSchemasToGetTypes')]
+    public function itGetsTypes(array $expected, Partial\Schema $schema): void
+    {
+        $sut = new Schema(new Identifier(''), $schema);
+
+        self::assertEqualsCanonicalizing($expected, $sut->getTypes());
+    }
+
     public static function provideInvalidComplexSchemas(): Generator
     {
         $xOfs = [
@@ -449,6 +462,57 @@ class SchemaTest extends TestCase
                 maximum: 5,
                 minimum: 1,
             ),
+        ];
+    }
+
+    /**
+     * @return \Generator<array{ 0:Type[], 1:Partial\Schema }>
+     */
+    public static function provideSchemasToGetTypes(): Generator
+    {
+        yield 'no type' => [
+            Type::casesForVersion(OpenAPIVersion::Version_3_0),
+            PartialHelper::createSchema(),
+        ];
+
+        yield 'nullable' => [
+            [Type::Null, ...Type::casesForVersion(OpenAPIVersion::Version_3_0)],
+            PartialHelper::createSchema(nullable: true)
+        ];
+
+        yield 'string' => [[Type::String], PartialHelper::createSchema(type: 'string')];
+        yield 'integer' => [[Type::Integer], PartialHelper::createSchema(type: 'integer')];
+        yield 'number' => [[Type::Number], PartialHelper::createSchema(type: 'number')];
+        yield 'boolean' => [[Type::Boolean], PartialHelper::createSchema(type: 'boolean')];
+        yield 'array' => [
+            [Type::Array],
+            PartialHelper::createSchema(type: 'array', items: PartialHelper::createSchema()),
+        ];
+        yield 'object' => [[Type::Object], PartialHelper::createSchema(type: 'object')];
+
+        yield 'nullable string' => [
+            [Type::String, Type::Null],
+            PartialHelper::createSchema(type: 'string', nullable: true),
+        ];
+        yield 'nullable integer' => [
+            [Type::Integer, Type::Null],
+            PartialHelper::createSchema(type: 'integer', nullable: true),
+        ];
+        yield 'nullable number' => [
+            [Type::Number, Type::Null],
+            PartialHelper::createSchema(type: 'number', nullable: true),
+        ];
+        yield 'nullable boolean' => [
+            [Type::Boolean, Type::Null],
+            PartialHelper::createSchema(type: 'boolean', nullable: true),
+        ];
+        yield 'nullable array' => [
+            [Type::Array, Type::Null],
+            PartialHelper::createSchema(type: 'array', nullable: true, items: PartialHelper::createSchema()),
+        ];
+        yield 'nullable object' => [
+            [Type::Object, Type::Null],
+            PartialHelper::createSchema(type: 'object', nullable: true),
         ];
     }
 }


### PR DESCRIPTION
We may need to consider how to make this consistent:

null would imply `type` has not been specified, thus can be any type.

In 3.1 null is a type, so not specifying `type` means that null is acceptable.

But in 3.0 null is not a type, `nullable` is a keyword. So if `type` is unspecified, but `nullable` is set to false... null is not acceptable.

https://github.com/membrane-php/openapi-reader/blob/88427b27fa55f968f8a56cc10e5a6b01d79e45ca/src/ValueObject/Valid/V30/Schema.php#L150-L154

Therefore, not specifying `type` has different meaning, depending on the version.

### Proposed Solution

We have getTypes() return _all_ acceptable types. 

#### Advantages

- We get a version agnostic "this is what it can be"
    - We get a version agnostic "this can|can't be null"

#### Disadvantages

We cannot rely on getTypes() to tell if it was unspecified.
To know if a type was specified, we would have to look at the property `$type`.
Thus we would want something like this when using it:

```php
if (isset($schema->type)) {
    $types = $schema->getTypes();
    // do something...
}
```

