### PR TITLE
Add additional keywords

### DIFF
--- a/src/Factory/V30/FromCebe.php
+++ b/src/Factory/V30/FromCebe.php
@@ -175,6 +175,8 @@ final class FromCebe
                 self::createSchema($schema->additionalProperties) ?? true) :
                 true,
             format: $schema->format ?? null,
+            title: $schema->title ?? null,
+            description: $schema->description ?? null,
         );
     }
 

--- a/src/ValueObject/Partial/Schema.php
+++ b/src/ValueObject/Partial/Schema.php
@@ -124,6 +124,12 @@ final class Schema
          * https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-7
          */
         public string|null $format = null,
+        /**
+         * Keywords that provide additional metadata
+         * https://json-schema.org/draft/2020-12/json-schema-validation#section-9
+         */
+        public string|null $title = null,
+        public string|null $description = null,
     ) {
     }
 }

--- a/src/ValueObject/Valid/V30/Schema.php
+++ b/src/ValueObject/Valid/V30/Schema.php
@@ -57,6 +57,9 @@ final class Schema extends Validated implements Valid\Schema
 
     public readonly string|null $format;
 
+    public readonly string|null $title;
+    public readonly string|null $description;
+
     /** @var Type[] */
     private readonly array $typesItCanBe;
 
@@ -103,6 +106,9 @@ final class Schema extends Validated implements Valid\Schema
             null;
 
         $this->format = $schema->format;
+
+        $this->title = $schema->title;
+        $this->description = $schema->description;
 
         $this->typesItCanBe = array_map(
             fn($t) => Type::from($t),

--- a/tests/fixtures/Helper/PartialHelper.php
+++ b/tests/fixtures/Helper/PartialHelper.php
@@ -160,6 +160,8 @@ final class PartialHelper
         array|null $oneOf = null,
         Schema|null $not = null,
         string|null $format = null,
+        string|null $title = null,
+        string|null $description = null,
     ): Schema {
         return new Schema(
             type: $type,
@@ -187,6 +189,8 @@ final class PartialHelper
             items: $items,
             properties: $properties,
             format: $format,
+            title: $title,
+            description: $description,
         );
     }
 }


### PR DESCRIPTION
_title_ is used by Membrane core for identification if possible. 

It may also be beneficial for identification elsewhere in the reader (i.e. Identifiers in allOfs)

_description_ is not used, but is simple to support.