### PR TITLE
Validate properties have keys

### DIFF
--- a/src/Exception/InvalidOpenAPI.php
+++ b/src/Exception/InvalidOpenAPI.php
@@ -409,4 +409,16 @@ final class InvalidOpenAPI extends RuntimeException
 
         return new self($message);
     }
+
+    public static function mustHaveStringKeys(
+        Identifier $identifier,
+        string $keyword,
+    ): self {
+        $message = <<<TEXT
+            $identifier
+            $keyword MUST be specified an array with string keys
+            TEXT;
+
+        return new self($message);
+    }
 }

--- a/src/ValueObject/Valid/V30/Schema.php
+++ b/src/ValueObject/Valid/V30/Schema.php
@@ -296,17 +296,24 @@ final class Schema extends Validated implements Valid\Schema
     }
 
     /**
-     * @param null|array<Partial\Schema> $subSchemas
-     * @return array<Schema>
+     * @param array<string, Partial\Schema> $properties
+     * @return array<string, Schema>
      */
-    private function validateProperties(?array $subSchemas): array
+    private function validateProperties(?array $properties): array
     {
-        $subSchemas ??= [];
+        $properties ??= [];
 
         $result = [];
-        foreach ($subSchemas as $index => $subSchema) {
-            $result[] = new Schema(
-                $this->getIdentifier()->append("properties($index)"),
+        foreach ($properties as $key => $subSchema) {
+            if (!is_string($key)) {
+                throw InvalidOpenAPI::mustHaveStringKeys(
+                    $this->getIdentifier(),
+                    'properties',
+                );
+            }
+
+            $result[$key] = new Schema(
+                $this->getIdentifier()->append("properties($key)"),
                 $subSchema
             );
         }


### PR DESCRIPTION
_properties_ MUST be an object, a JSON object that is.

This PR fixes an issue with the keys being removed.

It also tests that _properties_ without string keys throw an exception.