### PR TITLE
Update dependency to handle 3.1 parity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require": {
     "php": "^8.1.0",
-    "devizzent/cebe-php-openapi": "^1.1.0"
+    "devizzent/cebe-php-openapi": "^1.1.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5.36",


### PR DESCRIPTION
This updates the dependency to the earliest tag capable of handling numeric exclusiveMax and exclusiveMinimum.

This is required for us to get parity of keywords between 3.0 and 3.1